### PR TITLE
Revert: undo camelCase serialization fixes (#49, #50)

### DIFF
--- a/smallestai/atoms/agent/events.py
+++ b/smallestai/atoms/agent/events.py
@@ -163,13 +163,11 @@ class TransferOption(BaseModel):
 class SDKAgentTransferConversationEvent(
     SDKAgentEvent, type=EventType.AGENT_TRANSFER_CONVERSATION.value
 ):
-    model_config = ConfigDict(populate_by_name=True)
-
-    transfer_call_number: str = Field(alias="transferCallNumber")
-    transfer_options: TransferOption = Field(alias="transferOptions")
+    transfer_call_number: str
+    transfer_options: TransferOption
     on_hold_music: Optional[
         Literal["ringtone", "relaxing_sound", "uplifting_beats", "none"]
-    ] = Field(default=None, alias="onHoldMusic")
+    ]
 
 
 class SDKSystemInitEvent(SDKSystemEvent, type=EventType.SYSTEM_INIT.value):

--- a/smallestai/atoms/agent/session.py
+++ b/smallestai/atoms/agent/session.py
@@ -49,7 +49,7 @@ class EventCodec:
         return json.dumps(
             {
                 "type": data.type,
-                **data.model_dump(mode="json", by_alias=True),
+                **data.model_dump(mode="json"),
             }
         ).encode()
 

--- a/smallestai/cli/lib/chat.py
+++ b/smallestai/cli/lib/chat.py
@@ -174,13 +174,11 @@ class TransferOption(BaseModel):
 class SDKAgentTransferConversationEvent(
     SDKAgentEvent, type=EventType.AGENT_TRANSFER_CONVERSATION.value
 ):
-    model_config = ConfigDict(populate_by_name=True)
-
-    transfer_call_number: str = Field(alias="transferCallNumber")
-    transfer_options: TransferOption = Field(alias="transferOptions")
+    transfer_call_number: str
+    transfer_options: TransferOption
     on_hold_music: Optional[
         Literal["ringtone", "relaxing_sound", "uplifting_beats", "none"]
-    ] = Field(default=None, alias="onHoldMusic")
+    ]
 
 
 class SDKSystemInitEvent(SDKSystemEvent, type=EventType.SYSTEM_INIT.value):
@@ -295,7 +293,7 @@ class SDKCodec:
         return json.dumps(
             {
                 "type": data.type,
-                **data.model_dump(mode="json", by_alias=True),
+                **data.model_dump(mode="json"),
             }
         ).encode()
 


### PR DESCRIPTION
## Summary
- Reverts commit c5b7f0b: fix: use by_alias=True in EventCodec for correct camelCase serialization (#49)
- Reverts commit 8e3b138: fix: add camelCase aliases to SDKAgentTransferConversationEvent (#50)

## Test plan
- [x] Verify SDK functionality without the reverted changes
- [x] Confirm serialization behavior is as expected