### PR TITLE
feat: KB scrape helpers and background sound options

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ if __name__ == "__main__":
     main()
  ```   
 
+<Tip>
+  Knowledge Base helper supports **PDF uploads** (via `add_file` / `upload_media_to_knowledge_base`) and **URL scraping** (via `scrape_urls`). Text upload may not be available via API yet; if it fails, add text from the dashboard.
+</Tip>
+
+<Tip>
+  To add ambient noise to an agent, set `backgroundSound` when creating the agent. Supported options: `""` (none), `"office"`, `"cafe"`, `"call_center"`, `"static"`.
+</Tip>
+
 ### Configuring workflows to drive conversations
 
 An agent can be configured with a graph-based workflow to help it drive meaningful conversations. You can explore making one on our [platform](https://atoms.smallest.ai/dashboard/agents). Refer to our [documentation](https://atoms-docs.smallest.ai/deep-dive/workflow/what-is-a-workflow) for learning more extensively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smallestai"
-version = "4.2.1"
+version = "4.3.0"
 description = "Official Python client for the Smallest AI API"
 authors = [{ name = "Smallest", email = "support@smallest.ai" }]
 readme = "README.md"

--- a/smallestai/atoms/kb.py
+++ b/smallestai/atoms/kb.py
@@ -66,9 +66,9 @@ class KB:
         Args:
             name: KB name
             description: KB description
-            file_paths: List of file paths to upload
+            file_paths: List of PDF file paths to upload
             urls: List of URLs to scrape
-            text: Text content to add
+            text: Text content (may not be available via API yet)
         
         Returns:
             Created KB data
@@ -91,24 +91,18 @@ class KB:
         if isinstance(kb_id, dict):
             kb_id = kb_id.get("_id")
         
-        # Step 2: Upload Files
+        # Step 2: Upload PDF Files
         if file_paths:
-            files_url = f"{self.base_url}/knowledgebase/{kb_id}/items"
             for file_path in file_paths:
-                with open(file_path, "rb") as f:
-                    file_upload = {"file": f}
-                    requests.post(files_url, headers=self._get_headers(), files=file_upload)
+                self.add_file(kb_id, file_path)
         
-        # Step 3: Add URLs
+        # Step 3: Scrape URLs
         if urls:
-            urls_url = f"{self.base_url}/knowledgebase/{kb_id}/items/upload-url"
-            for u in urls:
-                requests.post(urls_url, headers=headers, json={"url": u})
+            self.scrape_urls(kb_id, urls)
         
-        # Step 4: Add Text
+        # Step 4: Add text (may not be available yet)
         if text:
-            text_url = f"{self.base_url}/knowledgebase/{kb_id}/items/upload-text"
-            requests.post(text_url, headers=headers, json={"text": text})
+            self.add_text(kb_id, text)
         
         # Return consistent format
         return {"status": True, "data": {"_id": kb_id}}
@@ -134,32 +128,95 @@ class KB:
         response.raise_for_status()
         return response.json()
     
+    def get_items(self, kb_id: str) -> Dict[str, Any]:
+        """Get all items in a knowledge base."""
+        url = f"{self.base_url}/knowledgebase/{kb_id}/items"
+        response = requests.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()
+    
+    def delete_item(self, kb_id: str, item_id: str) -> Dict[str, Any]:
+        """Delete an item from a knowledge base."""
+        url = f"{self.base_url}/knowledgebase/{kb_id}/items/{item_id}"
+        response = requests.delete(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()
+    
     # =========================================================================
     # Content Management
     # =========================================================================
     
     def add_file(self, kb_id: str, file_path: str) -> Dict[str, Any]:
-        """Add a file to the knowledge base."""
-        url = f"{self.base_url}/knowledgebase/{kb_id}/items"
+        """
+        Add a PDF file to the knowledge base.
+        
+        Args:
+            kb_id: Knowledge base ID
+            file_path: Path to PDF file
+            
+        Returns:
+            Upload response
+            
+        Note:
+            Only PDF files are supported.
+        """
+        url = f"{self.base_url}/knowledgebase/{kb_id}/items/upload-media"
+        
         with open(file_path, "rb") as f:
-            response = requests.post(url, headers=self._get_headers(), files={"file": f})
+            files = {"media": (os.path.basename(file_path), f, "application/pdf")}
+            response = requests.post(url, headers=self._get_headers(), files=files)
+        
         response.raise_for_status()
         return response.json()
     
-    def add_url(self, kb_id: str, source_url: str) -> Dict[str, Any]:
-        """Add a URL to scrape to the knowledge base."""
-        url = f"{self.base_url}/knowledgebase/{kb_id}/items/upload-url"
+    def scrape_urls(self, kb_id: str, urls: List[str]) -> Dict[str, Any]:
+        """
+        Scrape URLs and add content to knowledge base.
+        
+        Args:
+            kb_id: Knowledge base ID
+            urls: List of URLs to scrape
+            
+        Returns:
+            Scrape response
+        """
+        url = f"{self.base_url}/knowledgebase/{kb_id}/scrape-urls"
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
-        response = requests.post(url, headers=headers, json={"url": source_url})
+        
+        response = requests.post(url, headers=headers, json={"urls": urls})
         response.raise_for_status()
         return response.json()
     
+    def get_scraped_urls(self, kb_id: str) -> Dict[str, Any]:
+        """Get all scraped URLs for a knowledge base."""
+        url = f"{self.base_url}/knowledgebase/{kb_id}/scraped-urls"
+        response = requests.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()
+    
+    # Deprecated/legacy methods
+    def add_url(self, kb_id: str, source_url: str) -> Dict[str, Any]:
+        """
+        DEPRECATED: Use scrape_urls() instead.
+        """
+        return self.scrape_urls(kb_id, [source_url])
+    
     def add_text(self, kb_id: str, text: str) -> Dict[str, Any]:
-        """Add text content to the knowledge base."""
+        """
+        Add text content to knowledge base.
+        
+        Note: This endpoint may not be available yet.
+        If it fails, use the dashboard to add text content.
+        """
         url = f"{self.base_url}/knowledgebase/{kb_id}/items/upload-text"
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
+        
         response = requests.post(url, headers=headers, json={"text": text})
+        if response.status_code == 404:
+            print("Warning: Text upload API not available. Use dashboard instead.")
+            return {"status": False, "error": "Text upload not available via API"}
+        
         response.raise_for_status()
         return response.json()

--- a/smallestai/atoms/models/create_agent_request.py
+++ b/smallestai/atoms/models/create_agent_request.py
@@ -29,7 +29,7 @@ class CreateAgentRequest(BaseModel):
     """ # noqa: E501
     name: StrictStr
     description: Optional[StrictStr] = None
-    background_sound: Optional[StrictBool] = Field(default=False, description="Whether to add ambient background sound during calls. Currently provides office ambience by default. Additional sound options available upon request.", alias="backgroundSound")
+    background_sound: Optional[StrictStr] = Field(default=None, description="Background sound option: '', 'office', 'cafe', 'call_center', 'static'", alias="backgroundSound")
     language: Optional[CreateAgentRequestLanguage] = None
     global_knowledge_base_id: Optional[StrictStr] = Field(default=None, description="The global knowledge base ID of the agent. You can create a global knowledge base by using the /knowledgebase endpoint and assign it to the agent. The agent will use this knowledge base for its responses.", alias="globalKnowledgeBaseId")
     slm_model: Optional[StrictStr] = Field(default='electron', description="The LLM model to use for the agent. LLM model will be used to generate the response and take decisions based on the user's query.", alias="slmModel")


### PR DESCRIPTION
## Summary
- Add KB helpers for scraping URLs and managing items
- Update backgroundSound field to accept string options
- Document usage in README

## Details
### Knowledge Base
-  now funnels to helper methods:
  - PDFs via  → 
  - URL scraping via  → 
  - Text upload retained; warns if endpoint unavailable
- Helpers added: , , 
-  marked deprecated (wraps )

### Agent background sound
-  now accepts:  (none), , , , 

### Version / Docs
- Bump version to 4.3.0
- README: note KB PDF/URL support and backgroundSound options

## Testing
- Manual smoke: import KB, create() with urls=[], file_paths=None; add_file(); scrape_urls(); get_items() on dummy IDs (no requests sent here)

---
## EntelligenceAI PR Summary 
 Version 4.3.0 release expanding knowledge base management and agent background sound configuration options.
- Refactored KB methods to use updated API endpoints: `/items/upload-media` for files, `/scrape-urls` for batch URL processing
- Added KB item management methods: `get_items()`, `delete_item()`, `get_scraped_urls()`
- Changed agent `background_sound` parameter from boolean to string enum supporting '', 'office', 'cafe', 'call_center', 'static'
- Updated documentation with KB capabilities and background sound configuration guidance
- Deprecated `add_url()` in favor of `scrape_urls()` for batch processing
- Added error handling for `add_text()` with API availability warnings 

