### PR TITLE
fix: update outdated class names and imports in README (fixes #46)

### DIFF
--- a/smallestai/waves/__init__.py
+++ b/smallestai/waves/__init__.py
@@ -2,4 +2,7 @@ from smallestai.waves.waves_client import WavesClient
 from smallestai.waves.async_waves_client import AsyncWavesClient
 from smallestai.waves.stream_tts import WavesStreamingTTS, TTSConfig
 
-__all__ = ["WavesClient", "AsyncWavesClient", "WavesStreamingTTS", "TTSConfig"]
+# Backwards-compatible alias for the renamed class (see issue #46)
+TextToAudioStream = WavesStreamingTTS
+
+__all__ = ["WavesClient", "AsyncWavesClient", "WavesStreamingTTS", "TTSConfig", "TextToAudioStream"]


### PR DESCRIPTION
`TextToAudioStream` was renamed to `WavesStreamingTTS` and `Smallest` / `AsyncSmallest` were renamed to `WavesClient` / `AsyncWavesClient` but the README still referenced the old names and `from smallest import ...` paths. this caused `ImportError` for users following the documentation (#46).

## changes

### README.md

- updated all imports from:

  ```python
  from smallest import ...
  ```

  to:

  ```python
  from smallestai.waves import ...
  ```

- replaced:
  - `TextToAudioStream` → `WavesStreamingTTS`
  - `Smallest` → `WavesClient`
  - `AsyncSmallest` → `AsyncWavesClient`

- rewrote LLM-to-Speech examples to use the current `WavesStreamingTTS` + `TTSConfig` constructor.

### `smallestai/waves/__init__.py`

- added a backwards-compatible alias:

  ```python
  TextToAudioStream = WavesStreamingTTS
  ```

  so existing user code continues to work.

## testing

the existing test suite (`tests/waves/test_streaming_ws.py`) tests `WavesStreamingTTS` directly and requires live API keys, so no existing tests are affected by this change.

closes #46