### PR TITLE
fix(waves): stream_tts shim → /tts/live (legacy URL retired 2026-07-14) [5.1.1]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+## 5.1.1 - 2026-07-15
+
+Patch — fix the streaming-TTS compat shim (`WavesStreamingTTS`/`TTSConfig`).
+
+* The legacy per-model endpoint `wss://.../waves/v1/lightning-v3.1/get_speech/stream`
+  **retired 2026-07-14**, which broke `WavesStreamingTTS` on 5.0.0/5.1.0. The shim now
+  targets the unified `wss://api.smallest.ai/waves/v1/tts/live`.
+* `TTSConfig` gains a `model` field (default `lightning_v3.1`; set `lightning_v3.1_pro`
+  for the Pro pool) — the model was previously encoded in the URL path.
+* Verified live end-to-end (streams PCM chunks from `/tts/live`). No other changes.
+
 ## 5.1.0 - 2026-06-22
 
 Additive completeness, naming, and spec-correctness release (generator pinned to 5.12.12).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.1.0"
+version = "5.1.1"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/waves/stream_tts.py
+++ b/src/smallestai/waves/stream_tts.py
@@ -3,10 +3,13 @@ WavesStreamingTTS — thin compatibility shim for the legacy
 `from smallestai.waves import WavesStreamingTTS, TTSConfig` pattern
 shipped in smallestai==4.3.1.
 
-This wraps the Lightning v3.1 streaming WebSocket endpoint
-(`wss://api.smallest.ai/waves/v1/lightning-v3.1/get_speech/stream`).
+This wraps the unified TTS streaming WebSocket endpoint
+(`wss://api.smallest.ai/waves/v1/tts/live`). The old per-model URL
+`.../waves/v1/lightning-v3.1/get_speech/stream` retired 2026-07-14, so the
+model is now selected via the `model` payload field (default `lightning_v3.1`;
+set `lightning_v3.1_pro` for the Pro pool).
 
-Code that worked on 4.3.1 keeps working on 4.4.0 with one
+Code that worked on 4.3.1 keeps working with one
 behavior change: the underlying model is `lightning-v3.1` (not the
 deprecated `lightning-v2`). This means:
   - Removed `consistency` param (v2-only — silently dropped if passed).
@@ -39,6 +42,7 @@ class TTSConfig:
     """
     voice_id: str
     api_key: str
+    model: str = "lightning_v3.1"
     language: str = "en"
     sample_rate: int = 24000
     speed: float = 1.0
@@ -59,9 +63,10 @@ class WavesStreamingTTS:
         audio_chunks = list(streaming_tts.synthesize("Hello world"))
     """
 
-    # Lightning v3.1 streaming endpoint. Old 4.3.1 hardcoded the deprecated
-    # v2 endpoint — that was a bug and is fixed in 4.4.0.
-    WS_URL = "wss://api.smallest.ai/waves/v1/lightning-v3.1/get_speech/stream"
+    # Unified TTS streaming endpoint. The old per-model URL
+    # `.../waves/v1/lightning-v3.1/get_speech/stream` retired 2026-07-14; this shim
+    # now targets /tts/live and picks the model via the `model` payload field.
+    WS_URL = "wss://api.smallest.ai/waves/v1/tts/live"
 
     def __init__(self, config: TTSConfig):
         self.config = config
@@ -79,6 +84,7 @@ class WavesStreamingTTS:
     def _create_payload(self, text: str, continue_stream: bool = False, flush: bool = False) -> dict:
         payload: dict = {
             "voice_id": self.config.voice_id,
+            "model": self.config.model,
             "text": text,
             "language": self.config.language,
             "sample_rate": self.config.sample_rate,

--- a/tests/custom/test_waves_shim_import.py
+++ b/tests/custom/test_waves_shim_import.py
@@ -33,3 +33,18 @@ def test_tts_config_rejects_v2_only_consistency_param() -> None:
 
     with pytest.raises(TypeError):
         TTSConfig(voice_id="magnus", api_key="test-key", consistency=0.5)  # type: ignore[call-arg]
+
+
+def test_streaming_url_is_current_tts_live() -> None:
+    # The per-model `.../lightning-v3.1/get_speech/stream` URL retired 2026-07-14.
+    # Guard against regressing back to a retired endpoint.
+    from smallestai.waves import WavesStreamingTTS
+
+    assert WavesStreamingTTS.WS_URL == "wss://api.smallest.ai/waves/v1/tts/live"
+
+
+def test_tts_config_model_default() -> None:
+    from smallestai.waves import TTSConfig
+
+    assert TTSConfig(voice_id="magnus", api_key="k").model == "lightning_v3.1"
+    assert TTSConfig(voice_id="magnus", api_key="k", model="lightning_v3.1_pro").model == "lightning_v3.1_pro"


### PR DESCRIPTION
Legacy `wss://.../waves/v1/lightning-v3.1/get_speech/stream` **retired 2026-07-14**, breaking `WavesStreamingTTS` on 5.0.0/5.1.0. Fix: point the shim at unified `wss://api.smallest.ai/waves/v1/tts/live` + add `TTSConfig.model` (default `lightning_v3.1`). Verified live (19 chunks/138KB PCM); mypy + make verify green. Ships as **5.1.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)