### PR TITLE
fix(cli): correct agent-crew deploy layout warning (5.3.2)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+## 5.3.2 - 2026-07-30
+
+Corrects the agent-crew deploy layout warning. No API or behaviour changes.
+
+* **CLI** (`smallestai agent-crew deploy`): the pre-deploy check no longer claims a `src/`
+  layout or a `pyproject.toml` project fails the cloud build. Both build and run (verified end
+  to end). The check is now a short note: flat directory with `server.py` + `requirements.txt`
+  at the root is the simplest, best-tested path; if you use a `pyproject.toml` with no
+  `requirements.txt`, declare every runtime dependency in it.
+
 ## 5.3.1 - 2026-07-29
 
 Billing read endpoints, a call-log type fix, and clearer agent-crew deploy warnings. Additive; no breaking changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.3.1"
+version = "5.3.2"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/cli/agent_crew.py
+++ b/src/smallestai/cli/agent_crew.py
@@ -175,34 +175,24 @@ def initialise_agent_crew_app(
         console.print(f"[dim]Entry point: {entry_point}[/dim]")
         console.print(f"[dim]Agent ID: {agent_id}[/dim]\n")
 
-        # Pre-flight layout check. The cloud build runs `pip install .` from a
-        # pyproject before copying your source, so a src/ layout (or a nested
-        # entry point) fails there. The supported path is a flat directory with a
-        # requirements.txt (what the cookbook examples ship). Warn early instead
-        # of letting the build fail opaquely.
+        # Pre-flight layout note. Both a flat directory (server.py +
+        # requirements.txt at the root) and a src/ layout with a pyproject.toml
+        # build and run in the cloud. Flat + requirements.txt is what the cookbook
+        # examples ship and the best-tested path, so nudge toward it without
+        # blocking anything. One gotcha for pyproject projects: all runtime deps
+        # must be declared there (smallestai already pulls in the crew server's
+        # deps, so this is usually covered).
         has_pyproject = (dir_path / "pyproject.toml").exists()
         has_requirements = (dir_path / "requirements.txt").exists()
         has_src_dir = (dir_path / "src").is_dir()
         nested_entry = ("/" in entry_point) or ("\\" in entry_point)
-        if (has_pyproject and not has_requirements) or has_src_dir or nested_entry:
-            console.print("[yellow]⚠  Project layout may not build in the cloud:[/yellow]")
-            if has_src_dir or nested_entry:
-                console.print(
-                    "    [yellow]• src/ layout / nested entry point detected. The cloud "
-                    "build expects a flat directory with the entry file at the root "
-                    "(e.g. server.py), not under src/.[/yellow]"
-                )
-            if has_pyproject and not has_requirements:
-                console.print(
-                    "    [yellow]• pyproject.toml with no requirements.txt. The builder "
-                    "runs `pip install .` before your source is copied, which fails for "
-                    "src/ layouts. Add a requirements.txt (the builder prefers it and "
-                    "skips that step).[/yellow]"
-                )
+        if has_src_dir or nested_entry or (has_pyproject and not has_requirements):
             console.print(
-                "[dim]Supported layout: a flat directory with server.py + a "
-                "requirements.txt at the root. See the cookbook getting_started "
-                "example.[/dim]\n"
+                "[dim]Note: src/ + pyproject.toml layouts deploy fine. The simplest, "
+                "best-tested path is a flat directory with server.py + a "
+                "requirements.txt at the root (what the cookbook getting_started "
+                "example ships). If you use a pyproject with no requirements.txt, make "
+                "sure every runtime dependency is declared in it.[/dim]\n"
             )
 
         # Scan user code for env var references and warn — the deploy pipeline


### PR DESCRIPTION
The `agent-crew deploy` pre-flight check warned that a `src/` layout or a `pyproject.toml` project fails the cloud build. That is no longer true — both build and run end to end (atoms-platform #3179 deployed). The stale warning steers users away from a layout that works.

## Change
- Replace the yellow warning with a short dim note: flat directory (`server.py` + `requirements.txt` at the root) is the simplest, best-tested path; `src/` + `pyproject.toml` also deploys; if you use a pyproject with no requirements.txt, declare every runtime dependency in it.
- Bump version to 5.3.2 + changelog entry.

## Verification
Deployed a `src/`-layout crew (`src/server.py` + `src/assistant.py` + `pyproject.toml` py-modules, custom LLM) end to end: build SUCCEEDED, made live, placed calls, the custom LLM answered on the call. No API or runtime-behaviour changes in the SDK — CLI text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)