### PR TITLE
fix(cli): correct deploy message, drop misleading 'silent first call' guidance (5.3.4)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## 5.3.4 - 2026-07-31
+
+Corrects the deploy message. No API changes.
+
+* **CLI** (`smallestai agent-crew deploy`): drop the "first call can be silent, try
+  again" line from the post-deploy message. The crew is engaged at call time on the
+  current platform, so that guidance was misleading. The message now just says to
+  wait for the build to show Live before the first call.
+
 ## 5.3.3 - 2026-07-30
 
 CLI deploy now reports real build status, and a hand-written README. No API changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.3.3"
+version = "5.3.4"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/cli/agent_crew.py
+++ b/src/smallestai/cli/agent_crew.py
@@ -240,9 +240,8 @@ def initialise_agent_crew_app(
             console.print(f"[dim]Build ID: {result.build_id}[/dim]")
 
             # Poll the build to a terminal state instead of returning at "queued".
-            # The build has to reach SUCCEEDED before you can Make Live, and a
-            # freshly-live crew pod can need a moment to warm up before it serves
-            # the first call. Surfacing the real status here saves guessing.
+            # The build has to reach SUCCEEDED before you can Make Live, so
+            # surfacing the real status here saves guessing.
             console.print("[yellow]Building (this usually takes 1-2 min)...[/yellow]")
             terminal = {"SUCCEEDED", "BUILD_FAILED", "DEPLOY_FAILED", "FAILED"}
             last = None
@@ -267,10 +266,8 @@ def initialise_agent_crew_app(
             if status == "SUCCEEDED":
                 console.print("[bold green]✓ Build succeeded.[/bold green]")
                 console.print(
-                    "[dim]Next: `smallestai agent-crew builds` -> Make Live. "
-                    "The first call right after Make Live can take a few seconds "
-                    "while the pod warms up; if it's silent, give it a moment and "
-                    "try again.[/dim]"
+                    "[dim]Next: `smallestai agent-crew builds` -> Make Live, then "
+                    "wait for it to show Live before placing your first call.[/dim]"
                 )
             elif status in terminal:
                 console.print(


### PR DESCRIPTION
The 5.3.3 post-deploy message said the first call after Make Live could be silent and to retry. Platform investigation (PRO-2130) showed the crew is engaged at call time; the 'silent then works' pattern we saw was the pipecat routing fix (#1025) rolling out, not a per-deploy warm-up. That guidance sends users chasing a non-issue.

Drop the 'can be silent / try again' line; the message now just says to wait for the build to show Live before the first call. Version bump 5.3.4 + changelog. CLI-text-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)