### PR TITLE
feat(atoms): AgentTools helper to configure agent tools from code

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+## 5.4.0 - unreleased
+
+Configure agent tools (transfer_call, end_call, ...) from code.
+
+* **`atoms.helpers.AgentTools`**: new helper to read and write a single-prompt
+  agent's tools by agentId. It read-modify-writes, so the prompt and existing
+  tools are never wiped, and it targets the deployed write path (the versioned
+  drafts API is not reachable on the public host yet). `add_transfer_call(...)`
+  configures a transfer, including `on_hold_music` so the caller hears audio while
+  the transfer bridges instead of silence. Optional-None fields are stripped from
+  the payload (the API rejects nulls), and API error bodies are surfaced on failure.
+* Re-exported `Tool`, `SinglePromptConfig`, and `ToolTransferOption` from
+  `smallestai.atoms.helpers` (they are not exported from `atoms.types`).
+
 ## 5.3.4 - 2026-07-31
 
 Corrects the deploy message. No API changes.

--- a/src/smallestai/atoms/helpers/__init__.py
+++ b/src/smallestai/atoms/helpers/__init__.py
@@ -1,5 +1,6 @@
 """Utility classes for Atoms API operations."""
 
+from smallestai.atoms.helpers.agent_tools import AgentTools, AgentToolsError
 from smallestai.atoms.helpers.audience import Audience
 from smallestai.atoms.helpers.call import Call, CallAnalytics
 from smallestai.atoms.helpers.campaign import Campaign
@@ -14,7 +15,15 @@ from smallestai.atoms.helpers.versioning import (
     SecurityCheckFailedError,
 )
 
+# Re-export the tool-config models so callers don't need their deep module paths
+# (they are not exported from smallestai.atoms.types).
+from smallestai.atoms.types.single_prompt_config import SinglePromptConfig
+from smallestai.atoms.types.tool import Tool
+from smallestai.atoms.types.tool_transfer_option import ToolTransferOption
+
 __all__ = [
+    "AgentTools",
+    "AgentToolsError",
     "Audience",
     "CallAnalytics",
     "Call",
@@ -29,4 +38,7 @@ __all__ = [
     "DraftConflictError",
     "BaseRevisionUnavailableError",
     "SecurityCheckFailedError",
+    "SinglePromptConfig",
+    "Tool",
+    "ToolTransferOption",
 ]

--- a/src/smallestai/atoms/helpers/agent_tools.py
+++ b/src/smallestai/atoms/helpers/agent_tools.py
@@ -1,0 +1,286 @@
+"""
+Configure agent tools (transfer_call, end_call, api_call, ...) from code.
+
+Why this helper exists
+----------------------
+Setting tools on a single-prompt agent from code is possible today, but the raw
+surface has three footguns that make it feel impossible:
+
+* The versioned drafts API (``POST /agent/{id}/drafts/...``) is not reachable on
+  the public API host (it returns 404). The deployed write path is the legacy
+  workflow document.
+* That write path is ``PATCH /workflow/{workflowId}`` — it takes the *workflowId*
+  (``agent.workflowId``), not the agentId, and it does not merge: a partial
+  payload silently wipes the prompt and any tools you did not resend.
+* The wire fields are camelCase aliases (``transferNumber``, ``onHoldMusic``, ...),
+  easy to get wrong by hand.
+
+``AgentTools`` wraps all of that. You address agents by *agentId*, it always
+read-modify-writes (so the prompt and existing tools are never wiped), and you
+pass typed :class:`~smallestai.atoms.types.tool.Tool` models.
+
+Caveat: this writes the legacy workflow document directly. On an agent that is
+actively using the versioning system, a later version activation can overwrite
+the legacy doc. On the public API today versioning is not reachable, so the
+legacy doc is authoritative — but if you adopt drafts/versioning later, move tool
+edits into that flow.
+
+Usage
+-----
+    from smallestai.atoms.helpers import AgentTools
+
+    tools = AgentTools(api_key="sk_...")           # or SMALLEST_API_KEY env var
+
+    # add a transfer-to-human tool (merges, keeps prompt + other tools)
+    tools.add_transfer_call(
+        "AGENT_ID",
+        number="+15551234567",
+        transfer_type="cold_transfer",     # or "warm_transfer"
+        on_hold_music="relaxing_sound",    # audio while bridging, so it isn't blank
+    )
+
+    # inspect / remove
+    for t in tools.get_tools("AGENT_ID"):
+        print(t.type, t.name)
+    tools.remove_tool("AGENT_ID", "transfer_call")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Union
+
+import requests
+
+from smallestai.atoms.types.tool import Tool
+from smallestai.atoms.types.tool_transfer_option import ToolTransferOption
+
+logger = logging.getLogger("smallestai.atoms.agent_tools")
+
+DEFAULT_BASE_URL = "https://api.smallest.ai/atoms/v1"
+
+ToolInput = Union[Tool, Dict[str, Any]]
+
+
+class AgentToolsError(Exception):
+    """An agent could not be configured for tools (missing workflowId, wrong type, ...)."""
+
+
+class AgentTools:
+    """Read-modify-write tool configuration for single-prompt agents.
+
+    Can be used standalone::
+
+        tools = AgentTools(api_key="sk_...")
+
+    or pointed at a non-prod host::
+
+        tools = AgentTools(api_key="sk_...", base_url="https://api.dev.smallest.ai/atoms/v1")
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        *,
+        request_timeout: float = 30.0,
+    ):
+        self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
+        self.base_url = (base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)).rstrip("/")
+        self.request_timeout = request_timeout
+
+    # ------------------------------------------------------------------ transport
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+    def _unwrap(self, body: Any) -> Any:
+        # Atoms wraps successful reads as {"status": true, "data": {...}}.
+        if isinstance(body, dict) and "data" in body:
+            return body["data"]
+        return body
+
+    def _raise_for_status(self, resp: "requests.Response", method: str, path: str) -> None:
+        if resp.status_code < 400:
+            return
+        # Surface the API's error body — a bare HTTPError hides why the write failed.
+        try:
+            detail = resp.json()
+        except ValueError:
+            detail = (resp.text or "")[:300]
+        raise AgentToolsError(f"{method} {path} -> HTTP {resp.status_code}: {detail}")
+
+    def _get(self, path: str) -> Any:
+        resp = requests.get(f"{self.base_url}/{path}", headers=self._headers(), timeout=self.request_timeout)
+        self._raise_for_status(resp, "GET", path)
+        return self._unwrap(resp.json())
+
+    def _patch(self, path: str, json_body: Dict[str, Any]) -> Any:
+        resp = requests.patch(
+            f"{self.base_url}/{path}", headers=self._headers(), json=json_body, timeout=self.request_timeout
+        )
+        self._raise_for_status(resp, "PATCH", path)
+        return resp.json()
+
+    # ------------------------------------------------------------- config resolution
+    def _agent_doc(self, agent_id: str) -> Dict[str, Any]:
+        doc = self._get(f"agent/{agent_id}")
+        if not isinstance(doc, dict):
+            raise AgentToolsError(f"unexpected agent document for {agent_id!r}: {type(doc).__name__}")
+        return doc
+
+    def _workflow_id(self, agent_id: str) -> str:
+        doc = self._agent_doc(agent_id)
+        workflow_id = doc.get("workflowId") or doc.get("workflow_id")
+        if not workflow_id:
+            raise AgentToolsError(
+                f"agent {agent_id!r} has no workflowId; cannot configure tools on it"
+            )
+        workflow_type = doc.get("workflowType") or doc.get("workflow_type") or "single_prompt"
+        if workflow_type != "single_prompt":
+            raise AgentToolsError(
+                f"agent {agent_id!r} is workflow_type={workflow_type!r}; AgentTools only "
+                "configures single_prompt agents. For workflow_graph agents, tools live on "
+                "the graph's transfer_call / api_call nodes."
+            )
+        return workflow_id
+
+    def _workflow_config(self, agent_id: str) -> Dict[str, Any]:
+        cfg = self._get(f"agent/{agent_id}/workflow")
+        return cfg if isinstance(cfg, dict) else {}
+
+    # ------------------------------------------------------------------ serialization
+    @staticmethod
+    def _to_wire(tool: ToolInput) -> Dict[str, Any]:
+        if isinstance(tool, Tool):
+            wire = tool.dict(by_alias=True, exclude_none=True)
+        elif isinstance(tool, dict):
+            wire = dict(tool)
+        else:
+            raise AgentToolsError(f"tool must be a Tool or dict, got {type(tool).__name__}")
+        # Fern's exclude_none does NOT drop fields that were explicitly set to None
+        # (e.g. Tool(transfer_only_if_human=None)), and the API rejects nulls on
+        # optional fields ("Expected boolean, received null"). Strip them here.
+        return {k: v for k, v in wire.items() if v is not None}
+
+    @staticmethod
+    def _tool_name(tool_dict: Dict[str, Any]) -> Optional[str]:
+        return tool_dict.get("name")
+
+    # ------------------------------------------------------------------ public API
+    def get_tools(self, agent_id: str) -> List[Tool]:
+        """Return the agent's current tools as typed :class:`Tool` models.
+
+        Unknown/forward-compat tool shapes are returned as raw dicts rather than
+        dropped, so nothing is silently lost.
+        """
+        raw = self._workflow_config(agent_id).get("tools") or []
+        out: List[Tool] = []
+        for entry in raw:
+            try:
+                out.append(Tool(**entry))
+            except Exception:  # tolerate shapes the current models don't know about
+                out.append(entry)  # type: ignore[arg-type]
+        return out
+
+    def set_tools(
+        self,
+        agent_id: str,
+        tools: List[ToolInput],
+        *,
+        replace: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Write ``tools`` to the agent.
+
+        Default is a merge keyed by tool ``name`` (incoming tools overwrite an
+        existing tool of the same name; other existing tools and the prompt are
+        preserved). ``replace=True`` overwrites the whole tool list.
+
+        Returns the tool list (wire dicts) that was written.
+        """
+        workflow_id = self._workflow_id(agent_id)
+        cfg = self._workflow_config(agent_id)
+        prompt = cfg.get("prompt") or ""
+        incoming = [self._to_wire(t) for t in tools]
+
+        if replace:
+            merged = incoming
+        else:
+            by_name: Dict[Optional[str], Dict[str, Any]] = {}
+            for existing in cfg.get("tools") or []:
+                by_name[self._tool_name(existing)] = existing
+            for tool in incoming:
+                by_name[self._tool_name(tool)] = tool
+            merged = list(by_name.values())
+
+        logger.info(
+            "AgentTools.set_tools agent=%s workflow=%s tools=%s replace=%s",
+            agent_id,
+            workflow_id,
+            [self._tool_name(t) for t in merged],
+            replace,
+        )
+        self._patch(
+            f"workflow/{workflow_id}",
+            {"type": "single_prompt", "singlePromptConfig": {"prompt": prompt, "tools": merged}},
+        )
+        logger.info("AgentTools.set_tools OK agent=%s wrote %d tool(s)", agent_id, len(merged))
+        return merged
+
+    def remove_tool(self, agent_id: str, name: str) -> List[Dict[str, Any]]:
+        """Remove the tool with the given ``name`` (no-op if absent)."""
+        kept = [t for t in (self._workflow_config(agent_id).get("tools") or []) if self._tool_name(t) != name]
+        logger.info("AgentTools.remove_tool agent=%s name=%s", agent_id, name)
+        return self.set_tools(agent_id, kept, replace=True)  # type: ignore[arg-type]
+
+    def add_transfer_call(
+        self,
+        agent_id: str,
+        *,
+        number: str,
+        transfer_type: str = "cold_transfer",
+        name: str = "transfer_call",
+        description: Optional[str] = None,
+        on_hold_music: Optional[str] = None,
+        transfer_only_if_human: Optional[bool] = None,
+        enabled: bool = True,
+        **extra: Any,
+    ) -> Tool:
+        """Add a ``transfer_call`` tool that forwards the call to ``number``.
+
+        Parameters
+        ----------
+        number : str
+            E.164 destination, e.g. ``"+15551234567"``.
+        transfer_type : str
+            ``"cold_transfer"`` (hang up on connect) or ``"warm_transfer"``.
+        on_hold_music : str, optional
+            Audio played to the caller while the transfer bridges, so the line is
+            not silent. One of ``"ringtone"``, ``"relaxing_sound"``,
+            ``"uplifting_beats"``, ``"none"``.
+        transfer_only_if_human : bool, optional
+            Only transfer if a human (not voicemail) answers the destination.
+
+        The tool is merged into the agent's existing tools; the prompt and other
+        tools are preserved. Returns the :class:`Tool` that was written.
+        """
+        # Only pass optionals that have a value — the API rejects explicit nulls,
+        # and tool descriptions are restricted to a limited charset (no '+', so the
+        # default cannot embed the E.164 number).
+        kwargs: Dict[str, Any] = dict(
+            type="transfer_call",
+            name=name,
+            description=description
+            or "Transfer the call to a human agent or specialist when the caller asks.",
+            enabled=enabled,
+            transfer_number=number,
+            transfer_option=ToolTransferOption(type=transfer_type),
+        )
+        if on_hold_music is not None:
+            kwargs["on_hold_music"] = on_hold_music
+        if transfer_only_if_human is not None:
+            kwargs["transfer_only_if_human"] = transfer_only_if_human
+        kwargs.update(extra)
+        tool = Tool(**kwargs)
+        self.set_tools(agent_id, [tool])
+        return tool

--- a/tests/custom/test_agent_tools_helper.py
+++ b/tests/custom/test_agent_tools_helper.py
@@ -12,7 +12,30 @@ import json
 
 import pytest
 
-from smallestai.atoms.helpers import AgentTools, AgentToolsError, Tool
+from smallestai.atoms.helpers import (
+    AgentTools,
+    AgentToolsError,
+    SinglePromptConfig,
+    Tool,
+    ToolTransferOption,
+)
+
+
+def test_exported_tool_models_construct_and_serialize():
+    """The models re-exported from atoms.helpers build and serialize by alias."""
+    option = ToolTransferOption(type="warm_transfer")
+    tool = Tool(
+        type="transfer_call",
+        name="transfer_call",
+        description="Transfer to a specialist.",
+        transfer_number="+15551234567",
+        transfer_option=option,
+    )
+    config = SinglePromptConfig(prompt="You are helpful.", tools=[tool])
+    wire = config.dict(by_alias=True, exclude_none=True)
+    assert wire["prompt"] == "You are helpful."
+    assert wire["tools"][0]["transferNumber"] == "+15551234567"
+    assert wire["tools"][0]["transferOption"]["type"] == "warm_transfer"
 
 
 class FakeResponse:

--- a/tests/custom/test_agent_tools_helper.py
+++ b/tests/custom/test_agent_tools_helper.py
@@ -1,0 +1,195 @@
+"""Unit tests for the AgentTools helper.
+
+These exercise the read-modify-write logic with a fake transport (no network):
+- merge vs replace semantics keyed by tool name
+- prompt + other tools are preserved (never wiped)
+- the write targets PATCH /workflow/{workflowId} with camelCase wire fields
+- add_transfer_call builds a correct transfer_call Tool (incl. on_hold_music)
+- guardrails: missing workflowId and non-single_prompt agents raise
+"""
+
+import json
+
+import pytest
+
+from smallestai.atoms.helpers import AgentTools, AgentToolsError, Tool
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class FakeTransport:
+    """Records GET/PATCH calls and serves canned agent + workflow docs."""
+
+    def __init__(self, agent_doc, workflow_cfg):
+        self.agent_doc = agent_doc
+        self.workflow_cfg = workflow_cfg
+        self.patches = []  # (path, body)
+        self.gets = []
+
+    def get(self, url, headers=None, timeout=None):
+        self.gets.append(url)
+        if url.endswith("/workflow"):
+            return FakeResponse({"status": True, "data": self.workflow_cfg})
+        return FakeResponse({"status": True, "data": self.agent_doc})
+
+    def patch(self, url, headers=None, json=None, timeout=None):
+        self.patches.append((url, json))
+        # reflect the write into the stored config so a subsequent read sees it
+        self.workflow_cfg = dict(self.workflow_cfg)
+        self.workflow_cfg["tools"] = json["singlePromptConfig"]["tools"]
+        return FakeResponse({"status": True, "data": self.workflow_cfg})
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    def _make(agent_doc, workflow_cfg):
+        transport = FakeTransport(agent_doc, workflow_cfg)
+        monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.get", transport.get)
+        monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.patch", transport.patch)
+        helper = AgentTools(api_key="sk_test", base_url="https://api.example/atoms/v1")
+        return helper, transport
+
+    return _make
+
+
+AGENT_DOC = {"_id": "AG1", "workflowId": "WF1", "workflowType": "single_prompt"}
+
+
+def test_add_transfer_call_builds_correct_tool_and_targets_workflow(wired):
+    helper, t = wired(AGENT_DOC, {"prompt": "You are helpful.", "tools": []})
+    tool = helper.add_transfer_call(
+        "AG1", number="+15551234567", transfer_type="cold_transfer", on_hold_music="relaxing_sound"
+    )
+    assert isinstance(tool, Tool)
+    assert tool.transfer_number == "+15551234567"
+
+    # one PATCH, to the workflowId (not the agentId), single_prompt shape
+    assert len(t.patches) == 1
+    url, body = t.patches[0]
+    assert url.endswith("/workflow/WF1")
+    assert body["type"] == "single_prompt"
+    written = body["singlePromptConfig"]["tools"]
+    assert len(written) == 1
+    wire = written[0]
+    # camelCase aliases on the wire
+    assert wire["type"] == "transfer_call"
+    assert wire["transferNumber"] == "+15551234567"
+    assert wire["transferOption"] == {"type": "cold_transfer"}
+    assert wire["onHoldMusic"] == "relaxing_sound"
+    # prompt preserved
+    assert body["singlePromptConfig"]["prompt"] == "You are helpful."
+
+
+def test_none_optionals_are_stripped_from_wire(wired):
+    """Explicit-None optionals must not reach the API (it rejects nulls)."""
+    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": []})
+    # transfer_only_if_human omitted -> must be absent, not null
+    helper.add_transfer_call("AG1", number="+15551234567")
+    _, body = t.patches[0]
+    wire = body["singlePromptConfig"]["tools"][0]
+    assert "transferOnlyIfHuman" not in wire
+    assert "onHoldMusic" not in wire
+    # default description must be within the allowed charset (no '+')
+    assert "+" not in wire["description"]
+
+
+def test_user_tool_with_explicit_none_is_stripped(wired):
+    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": []})
+    tool = Tool(type="transfer_call", name="x", description="d", transfer_number="+1", transfer_only_if_human=None)
+    helper.set_tools("AG1", [tool])
+    _, body = t.patches[0]
+    assert "transferOnlyIfHuman" not in body["singlePromptConfig"]["tools"][0]
+
+
+def test_set_tools_merges_by_name_and_preserves_existing(wired):
+    existing = {"type": "end_call", "name": "end_call", "description": "bye", "enabled": True}
+    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": [existing]})
+    new_tool = Tool(type="transfer_call", name="transfer_call", description="d", transfer_number="+1")
+    helper.set_tools("AG1", [new_tool])
+
+    _, body = t.patches[0]
+    names = [tool["name"] for tool in body["singlePromptConfig"]["tools"]]
+    assert names == ["end_call", "transfer_call"]  # existing kept, new appended
+
+
+def test_set_tools_same_name_overwrites_not_duplicates(wired):
+    existing = {"type": "transfer_call", "name": "transfer_call", "transferNumber": "+1old"}
+    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": [existing]})
+    helper.add_transfer_call("AG1", number="+1new")
+
+    _, body = t.patches[0]
+    tools = body["singlePromptConfig"]["tools"]
+    assert len(tools) == 1
+    assert tools[0]["transferNumber"] == "+1new"
+
+
+def test_set_tools_replace_overwrites_all(wired):
+    existing = {"type": "end_call", "name": "end_call"}
+    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": [existing]})
+    helper.set_tools("AG1", [Tool(type="transfer_call", name="x", description="d", transfer_number="+1")], replace=True)
+
+    _, body = t.patches[0]
+    names = [tool["name"] for tool in body["singlePromptConfig"]["tools"]]
+    assert names == ["x"]  # end_call dropped
+
+
+def test_remove_tool(wired):
+    tools = [
+        {"type": "transfer_call", "name": "transfer_call"},
+        {"type": "end_call", "name": "end_call"},
+    ]
+    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": tools})
+    helper.remove_tool("AG1", "transfer_call")
+
+    _, body = t.patches[0]
+    names = [tool["name"] for tool in body["singlePromptConfig"]["tools"]]
+    assert names == ["end_call"]
+
+
+def test_get_tools_returns_typed(wired):
+    tools = [{"type": "transfer_call", "name": "transfer_call", "description": "d", "transferNumber": "+1"}]
+    helper, _ = wired(AGENT_DOC, {"prompt": "P", "tools": tools})
+    got = helper.get_tools("AG1")
+    assert len(got) == 1
+    assert isinstance(got[0], Tool)
+    assert got[0].transfer_number == "+1"
+
+
+def test_missing_workflow_id_raises(wired):
+    helper, _ = wired({"_id": "AG1", "workflowType": "single_prompt"}, {"prompt": "P", "tools": []})
+    with pytest.raises(AgentToolsError, match="no workflowId"):
+        helper.set_tools("AG1", [Tool(type="end_call", name="end_call", description="d")])
+
+
+def test_non_single_prompt_agent_raises(wired):
+    helper, _ = wired(
+        {"_id": "AG1", "workflowId": "WF1", "workflowType": "workflow_graph"}, {"prompt": "P", "tools": []}
+    )
+    with pytest.raises(AgentToolsError, match="workflow_graph"):
+        helper.add_transfer_call("AG1", number="+1")
+
+
+def test_api_error_body_is_surfaced(monkeypatch):
+    """A non-2xx write raises AgentToolsError carrying the API's error body."""
+
+    def bad_patch(url, headers=None, json=None, timeout=None):
+        return FakeResponse({"status": False, "error": "prompt is required"}, status_code=400)
+
+    def ok_get(url, headers=None, timeout=None):
+        if url.endswith("/workflow"):
+            return FakeResponse({"data": {"prompt": "P", "tools": []}})
+        return FakeResponse({"data": AGENT_DOC})
+
+    monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.get", ok_get)
+    monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.patch", bad_patch)
+    helper = AgentTools(api_key="sk_test", base_url="https://api.example/atoms/v1")
+    with pytest.raises(AgentToolsError, match="HTTP 400.*prompt is required"):
+        helper.add_transfer_call("AG1", number="+1")


### PR DESCRIPTION
## What

Adds `atoms.helpers.AgentTools` — a safe, high-level way to configure a single-prompt agent's tools (transfer_call, end_call, ...) **from code**.

```python
from smallestai.atoms.helpers import AgentTools

tools = AgentTools(api_key="sk_...")
tools.add_transfer_call(
    "AGENT_ID",
    number="+15551234567",
    transfer_type="cold_transfer",     # or "warm_transfer"
    on_hold_music="relaxing_sound",    # audio while bridging, so it isn't blank
)
```

## Why

Setting tools on an agent from code was effectively impossible through the public surface, which is why "transfer via SDK" felt unsupported:

- The versioned drafts API (`POST /agent/{id}/drafts/...`) returns **404 on the public API host** (the route lives in main-backend but isn't reachable from `api.smallest.ai`).
- The only **deployed** write path is `PATCH /workflow/{workflowId}` — it takes the *workflowId* (`agent.workflowId`), not the agentId; it does **not merge** (a partial payload silently wipes the prompt and any tools you didn't resend); and it uses camelCase wire aliases (`transferNumber`, `onHoldMusic`) that are easy to get wrong.
- The tool models (`Tool`, `SinglePromptConfig`, `ToolTransferOption`) aren't exported from `atoms.types`.

## How

`AgentTools`:
- addresses agents by **agentId** (resolves workflowId internally)
- always **read-modify-writes**, so prompt + existing tools are preserved
- `add_transfer_call(...)` sets `on_hold_music` so the transfer bridge plays audio instead of silence
- **strips explicit-None optionals** (the API rejects nulls: `transferOnlyIfHuman: Expected boolean, received null`) and uses a default description within the allowed charset (no `+`)
- **surfaces API error bodies** instead of a bare `HTTPError`
- guardrails: clear errors for missing workflowId / non-single_prompt agents
- structured `logging` on every write

Re-exports `Tool`, `SinglePromptConfig`, `ToolTransferOption` from `atoms.helpers`.

## Testing

- 11 unit tests (mocked transport): merge vs replace, prompt/tool preservation, None-stripping, error-body surfacing, guardrails.
- Verified **live against prod** end to end: create agent → `add_transfer_call` (with music + only-if-human) → merged with existing `end_call` → read back correct → `remove_tool` → `[end_call]`.

Part of the 5.4.0 transfer + greeting bundle. Runtime call verification tracked for post-merge.