### PR TITLE
fix(crew): make transfer on_hold_music optional

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,12 @@ Configure agent tools (transfer_call, end_call, ...) from code.
   the payload (the API rejects nulls), and API error bodies are surfaced on failure.
 * Re-exported `Tool`, `SinglePromptConfig`, and `ToolTransferOption` from
   `smallestai.atoms.helpers` (they are not exported from `atoms.types`).
+* **crew**: `SDKAgentTransferConversationEvent.on_hold_music` is now optional
+  (defaults to `None`). It was declared `Optional[...]` but without a default, so
+  it was effectively required — every crew transfer had to pass it (even as
+  `None`) or event construction raised a `ValidationError`. Callers that want
+  audio during the transfer bridge still pass `ringtone` / `relaxing_sound` /
+  `uplifting_beats`.
 
 ## 5.3.4 - 2026-07-31
 

--- a/src/smallestai/atoms/crew/events.py
+++ b/src/smallestai/atoms/crew/events.py
@@ -209,9 +209,11 @@ class SDKAgentTransferConversationEvent(
 ):
     transfer_call_number: str
     transfer_options: TransferOption
+    # Optional: audio played to the caller while the transfer bridges. Omit (None)
+    # to leave it to the platform default. Set a value to avoid a silent hold.
     on_hold_music: Optional[
         Literal["ringtone", "relaxing_sound", "uplifting_beats", "none"]
-    ]
+    ] = None
 
 
 class SDKSystemInitEvent(SDKSystemEvent, type=EventType.SYSTEM_INIT.value):

--- a/tests/custom/test_crew_transfer_onhold_optional.py
+++ b/tests/custom/test_crew_transfer_onhold_optional.py
@@ -1,0 +1,42 @@
+"""SDKAgentTransferConversationEvent.on_hold_music must be optional.
+
+Regression: the field was declared Optional[...] but without a default, so pydantic
+treated it as required — every crew transfer had to pass on_hold_music (even as None)
+or the event construction raised a ValidationError. It now defaults to None.
+"""
+
+import pytest
+
+from smallestai.atoms.crew.events import SDKAgentTransferConversationEvent, TransferOption
+
+
+def _transfer_option():
+    return TransferOption(type="cold_transfer")
+
+
+def test_on_hold_music_is_optional():
+    ev = SDKAgentTransferConversationEvent(
+        transfer_call_number="+15551234567",
+        transfer_options=_transfer_option(),
+    )
+    assert ev.on_hold_music is None
+    assert ev.transfer_call_number == "+15551234567"
+
+
+def test_on_hold_music_still_settable():
+    ev = SDKAgentTransferConversationEvent(
+        transfer_call_number="+15551234567",
+        transfer_options=_transfer_option(),
+        on_hold_music="relaxing_sound",
+    )
+    assert ev.on_hold_music == "relaxing_sound"
+
+
+@pytest.mark.parametrize("music", ["ringtone", "relaxing_sound", "uplifting_beats", "none"])
+def test_on_hold_music_accepts_all_options(music):
+    ev = SDKAgentTransferConversationEvent(
+        transfer_call_number="+1",
+        transfer_options=_transfer_option(),
+        on_hold_music=music,
+    )
+    assert ev.on_hold_music == music


### PR DESCRIPTION
## What
`SDKAgentTransferConversationEvent.on_hold_music` now defaults to `None`.

## Why
The field was declared `Optional[...]` but **without a default**, so pydantic treated it as **required**. Every crew transfer had to pass `on_hold_music` (even as `None`) or event construction raised a `ValidationError`. This is the papercut a customer hits when emitting a transfer from crew node code.

## How
Add `= None`. Callers that want audio during the transfer bridge (instead of a silent hold) still pass `ringtone` / `relaxing_sound` / `uplifting_beats`.

## Testing
6 unit tests: builds without `on_hold_music`, still settable, accepts all four options.

Part of the 5.4.0 transfer + greeting bundle.