### PR TITLE
feat(cli): smallestai calls — list/get/transcript/recording

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,9 @@ Configure agent tools (transfer_call, end_call, ...) from code.
   `None`) or event construction raised a `ValidationError`. Callers that want
   audio during the transfer bridge still pass `ringtone` / `relaxing_sound` /
   `uplifting_beats`.
+* **CLI** (`smallestai calls`): new `list`, `get`, `transcript`, and `recording`
+  subcommands to inspect call logs, details, transcripts, and recording URLs from
+  the terminal (read-only, dogfoods `client.atoms.calls`). Each supports `--json`.
 
 ## 5.3.4 - 2026-07-31
 

--- a/src/smallestai/cli/agents.py
+++ b/src/smallestai/cli/agents.py
@@ -5,44 +5,20 @@ and the SDK stay in lockstep automatically. Auth resolves from SMALLEST_API_KEY,
 key stored by `smallestai auth login` (~/.smallestai/credentials.json). SMALLEST_BASE_URL
 overrides the endpoint (dev rig).
 """
-import os
-
 import typer
 from rich.console import Console
 from rich.table import Table
 
 from smallestai.cli.lib.auth import AuthClient
+from smallestai.cli.lib.client import make_client as _client
+from smallestai.cli.lib.client import resolve_key as _resolve_key
 
 console = Console()
 
 DASHBOARD = "https://app.smallest.ai/dashboard/agents"
 RENT_NUMBERS = "https://app.smallest.ai/dashboard/phone-numbers/rent-numbers"
 
-
-def _resolve_key(auth_client: AuthClient) -> str:
-    key = os.environ.get("SMALLEST_API_KEY")
-    if not key:
-        creds = auth_client.get_credentials()
-        key = (creds or {}).get("access_token")
-    if not key:
-        console.print("[red]No API key. Set SMALLEST_API_KEY or run `smallestai auth login`.[/red]")
-        raise typer.Exit(1)
-    return key
-
-
-def _client(auth_client: AuthClient):
-    from smallestai import SmallestAI
-
-    key = _resolve_key(auth_client)
-    base = os.environ.get("SMALLEST_BASE_URL")
-    if base:
-        from smallestai.environment import SmallestAIEnvironment
-
-        base = base.rstrip("/")
-        ws = base.replace("https://", "wss://").replace("http://", "ws://")
-        env = SmallestAIEnvironment(atoms=f"{base}/atoms/v1", waves=base, waves_ws=ws)
-        return SmallestAI(api_key=key, environment=env)
-    return SmallestAI(api_key=key)
+__all__ = ["initialise_agents_app", "_client", "_resolve_key"]
 
 
 def initialise_agents_app(auth_client: AuthClient):

--- a/src/smallestai/cli/calls.py
+++ b/src/smallestai/cli/calls.py
@@ -1,0 +1,150 @@
+"""`smallestai calls …` — inspect call logs, details, transcripts, and recordings.
+
+Read-only, on top of the published SDK (`client.atoms.calls`). To place a call use
+`smallestai agents call`.
+"""
+
+import json as _json
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from smallestai.cli.lib.auth import AuthClient
+from smallestai.cli.lib.client import make_client
+
+console = Console()
+
+
+def _data(resp):
+    """Unwrap `.data` from an SDK response (or return the object itself)."""
+    return getattr(resp, "data", resp)
+
+
+def _fmt_dur(seconds) -> str:
+    try:
+        s = float(seconds)
+    except (TypeError, ValueError):
+        return "—"
+    return f"{int(s // 60)}m{int(s % 60):02d}s" if s >= 60 else f"{s:.1f}s"
+
+
+def initialise_calls_app(auth_client: AuthClient):
+    calls_app = typer.Typer(name="calls", help="Inspect call logs, transcripts, and recordings.")
+
+    @calls_app.command("list")
+    def list_calls(
+        agent_id: str = typer.Option(None, "--agent-id", help="Filter by agent id"),
+        limit: int = typer.Option(20, "--limit", help="Max rows"),
+        call_type: str = typer.Option(
+            None, "--type", help="telephony_inbound | telephony_outbound | webcall"
+        ),
+        status: str = typer.Option(None, "--status", help="Filter by status"),
+        as_json: bool = typer.Option(False, "--json", help="Emit raw JSON"),
+    ):
+        """List recent calls (most recent first)."""
+        kw = {"limit": limit}
+        if agent_id:
+            kw["agent_ids"] = agent_id
+        if call_type:
+            kw["call_types"] = call_type
+        if status:
+            kw["status_filter"] = status
+        data = _data(make_client(auth_client).atoms.calls.list(**kw))
+        logs = getattr(data, "logs", None) or []
+        if as_json:
+            console.print_json(_json.dumps([_row_dict(x) for x in logs], default=str))
+            return
+        table = Table("Call ID", "Type", "Status", "Dur", "From", "To", "When", title=f"Calls ({len(logs)})")
+        for x in logs:
+            table.add_row(
+                getattr(x, "call_id", None) or "—",
+                (getattr(x, "type", None) or "—").replace("telephony_", ""),
+                getattr(x, "status", None) or "—",
+                _fmt_dur(getattr(x, "duration", None)),
+                getattr(x, "from_", None) or "—",
+                getattr(x, "to", None) or "—",
+                str(getattr(x, "created_at", None) or "—")[:19],
+            )
+        console.print(table)
+
+    @calls_app.command("get")
+    def get_call(
+        call_id: str,
+        as_json: bool = typer.Option(False, "--json", help="Emit raw JSON"),
+    ):
+        """Show one call's details (status, duration, cost, recording, turn count)."""
+        d = _data(make_client(auth_client).atoms.calls.get(id=call_id))
+        if as_json:
+            console.print_json(d.json() if hasattr(d, "json") else _json.dumps(d, default=str))
+            return
+        transcript = getattr(d, "transcript", None) or []
+        console.print(f"[bold]{call_id}[/bold]")
+        console.print(f"  status        : {getattr(d, 'status', None)}")
+        console.print(f"  type          : {getattr(d, 'type', None)}")
+        console.print(f"  duration      : {_fmt_dur(getattr(d, 'duration', None))}")
+        console.print(f"  from -> to    : {getattr(d, 'from_', None)} -> {getattr(d, 'to', None)}")
+        console.print(f"  turns         : {len(transcript)}")
+        cost = getattr(d, "call_cost", None)
+        if cost is not None:
+            console.print(f"  cost          : {cost}")
+        fail = getattr(d, "call_failure_reason", None)
+        if fail:
+            console.print(f"  failure       : [yellow]{fail}[/yellow]")
+        rec = getattr(d, "recording_url", None)
+        console.print(f"  recording     : {rec or '[dim]none[/dim]'}")
+        console.print("  [dim]transcript: smallestai calls transcript " + call_id + "[/dim]")
+
+    @calls_app.command("transcript")
+    def transcript(
+        call_id: str,
+        as_json: bool = typer.Option(False, "--json", help="Emit raw JSON"),
+    ):
+        """Print a call's transcript, one turn per line."""
+        d = _data(make_client(auth_client).atoms.calls.get(id=call_id))
+        turns = getattr(d, "transcript", None) or []
+        if as_json:
+            console.print_json(
+                _json.dumps(
+                    [{"role": getattr(t, "role", None), "content": getattr(t, "content", None),
+                      "timestamp": getattr(t, "timestamp", None)} for t in turns],
+                    default=str,
+                )
+            )
+            return
+        if not turns:
+            console.print("[yellow]No transcript for this call.[/yellow]")
+            return
+        for t in turns:
+            role = getattr(t, "role", "?")
+            colour = "cyan" if role == "user" else "green"
+            console.print(f"[{colour}]{role}[/{colour}]: {getattr(t, 'content', '')}")
+
+    @calls_app.command("recording")
+    def recording(call_id: str):
+        """Print a call's recording URL(s)."""
+        d = _data(make_client(auth_client).atoms.calls.get(id=call_id))
+        url = getattr(d, "recording_url", None)
+        dual = getattr(d, "recording_dual_url", None)
+        if not url and not dual:
+            console.print("[yellow]No recording available for this call.[/yellow]")
+            raise typer.Exit(0)
+        if url:
+            console.print(url)
+        if dual and dual != url:
+            console.print(f"[dim]dual-channel:[/dim] {dual}")
+
+    return calls_app
+
+
+def _row_dict(x):
+    return {
+        "call_id": getattr(x, "call_id", None),
+        "type": getattr(x, "type", None),
+        "status": getattr(x, "status", None),
+        "duration": getattr(x, "duration", None),
+        "from": getattr(x, "from_", None),
+        "to": getattr(x, "to", None),
+        "recording_url": getattr(x, "recording_url", None),
+        "created_at": getattr(x, "created_at", None),
+    }

--- a/src/smallestai/cli/lib/client.py
+++ b/src/smallestai/cli/lib/client.py
@@ -1,0 +1,41 @@
+"""Shared SmallestAI client construction for the CLI.
+
+Dogfoods the published `SmallestAI` client so the CLI and SDK stay in lockstep.
+Auth resolves from SMALLEST_API_KEY, else the key stored by `smallestai auth
+login`. SMALLEST_BASE_URL overrides the endpoint (dev rig).
+"""
+
+import os
+
+import typer
+from rich.console import Console
+
+from smallestai.cli.lib.auth import AuthClient
+
+console = Console()
+
+
+def resolve_key(auth_client: AuthClient) -> str:
+    key = os.environ.get("SMALLEST_API_KEY")
+    if not key:
+        creds = auth_client.get_credentials()
+        key = (creds or {}).get("access_token")
+    if not key:
+        console.print("[red]No API key. Set SMALLEST_API_KEY or run `smallestai auth login`.[/red]")
+        raise typer.Exit(1)
+    return key
+
+
+def make_client(auth_client: AuthClient):
+    from smallestai import SmallestAI
+
+    key = resolve_key(auth_client)
+    base = os.environ.get("SMALLEST_BASE_URL")
+    if base:
+        from smallestai.environment import SmallestAIEnvironment
+
+        base = base.rstrip("/")
+        ws = base.replace("https://", "wss://").replace("http://", "ws://")
+        env = SmallestAIEnvironment(atoms=f"{base}/atoms/v1", waves=base, waves_ws=ws)
+        return SmallestAI(api_key=key, environment=env)
+    return SmallestAI(api_key=key)

--- a/src/smallestai/cli/main.py
+++ b/src/smallestai/cli/main.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from smallestai.cli.agent_crew import initialise_agent_crew_app
 from smallestai.cli.agents import initialise_agents_app
 from smallestai.cli.auth import initialise_auth_app
+from smallestai.cli.calls import initialise_calls_app
 from smallestai.cli.lib.atoms import AtomsAPIClient
 from smallestai.cli.lib.auth import AuthClient
 from smallestai.cli.lib.project_config import ProjectConfig
@@ -26,6 +27,9 @@ app.add_typer(auth_app, name="auth")
 
 agents_app = initialise_agents_app(auth_client)
 app.add_typer(agents_app, name="agents")
+
+calls_app = initialise_calls_app(auth_client)
+app.add_typer(calls_app, name="calls")
 
 
 def main():

--- a/tests/custom/test_cli_calls.py
+++ b/tests/custom/test_cli_calls.py
@@ -1,0 +1,103 @@
+"""Unit tests for `smallestai calls …` — rendering + SDK wiring with a fake client."""
+
+import types
+
+import pytest
+from typer.testing import CliRunner
+
+from smallestai.cli.calls import _fmt_dur, initialise_calls_app
+
+runner = CliRunner()
+
+
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+def _obj(**kw):
+    return types.SimpleNamespace(**kw)
+
+
+class FakeCalls:
+    def __init__(self, logs=None, call=None):
+        self._logs = logs or []
+        self._call = call
+        self.list_kwargs = None
+
+    def list(self, **kw):
+        self.list_kwargs = kw
+        return _Resp(_obj(logs=self._logs))
+
+    def get(self, id):
+        return _Resp(self._call)
+
+
+class FakeClient:
+    def __init__(self, calls):
+        self.atoms = _obj(calls=calls)
+
+
+@pytest.fixture
+def app_with(monkeypatch):
+    def _make(calls):
+        monkeypatch.setattr("smallestai.cli.calls.make_client", lambda auth: FakeClient(calls))
+        return initialise_calls_app(auth_client=None)
+
+    return _make
+
+
+def test_fmt_dur():
+    assert _fmt_dur(43.4) == "43.4s"
+    assert _fmt_dur(89) == "1m29s"
+    assert _fmt_dur(None) == "—"
+
+
+def test_list_renders_and_passes_filters(app_with):
+    calls = FakeCalls(logs=[
+        _obj(call_id="CALL-1", type="telephony_outbound", status="completed", duration=89,
+             from_="+111", to="+222", created_at="2026-08-04T09:06:07.000Z", recording_url="u"),
+    ])
+    app = app_with(calls)
+    res = runner.invoke(app, ["list", "--agent-id", "AG1", "--type", "telephony_outbound", "--limit", "5"])
+    assert res.exit_code == 0, res.output
+    assert "CALL-1" in res.output
+    assert "outbound" in res.output  # telephony_ stripped
+    # filters forwarded to the SDK
+    assert calls.list_kwargs == {"limit": 5, "agent_ids": "AG1", "call_types": "telephony_outbound"}
+
+
+def test_get_shows_fields_and_recording(app_with):
+    call = _obj(status="completed", type="telephony_outbound", duration=89, from_="+1", to="+2",
+                transcript=[_obj(role="user", content="hi")], call_cost=0.17,
+                call_failure_reason=None, recording_url="https://rec/x.wav")
+    app = app_with(FakeCalls(call=call))
+    res = runner.invoke(app, ["get", "CALL-9"])
+    assert res.exit_code == 0, res.output
+    assert "completed" in res.output
+    assert "turns" in res.output and "1" in res.output
+    assert "https://rec/x.wav" in res.output
+
+
+def test_transcript_prints_turns(app_with):
+    call = _obj(transcript=[_obj(role="user", content="hello"), _obj(role="assistant", content="hi there")])
+    app = app_with(FakeCalls(call=call))
+    res = runner.invoke(app, ["transcript", "CALL-9"])
+    assert res.exit_code == 0, res.output
+    assert "hello" in res.output and "hi there" in res.output
+
+
+def test_transcript_empty(app_with):
+    call = _obj(transcript=[])
+    app = app_with(FakeCalls(call=call))
+    res = runner.invoke(app, ["transcript", "CALL-9"])
+    assert res.exit_code == 0
+    assert "No transcript" in res.output
+
+
+def test_recording_absent(app_with):
+    call = _obj(recording_url=None, recording_dual_url=None)
+    app = app_with(FakeCalls(call=call))
+    res = runner.invoke(app, ["recording", "CALL-9"])
+    assert res.exit_code == 0
+    assert "No recording" in res.output


### PR DESCRIPTION
## What
New read-only `smallestai calls` command group, dogfooding `client.atoms.calls`:

- `calls list` — recent calls: id, type, status, duration, from→to, when (filters: `--agent-id`, `--type`, `--status`, `--limit`)
- `calls get <id>` — one call's status, duration, cost, recording, turn count
- `calls transcript <id>` — the conversation, one turn per line
- `calls recording <id>` — the recording URL(s)

All support `--json`.

## Why
The CLI could create/list/call agents but had no way to inspect what happened on a call. These are the read-paths the API already exposes.

## How
Extracts SDK-client construction into `cli/lib/client.py` (`make_client` / `resolve_key`) as a single source of truth, and points `agents.py` at it (removing the duplicated helpers). New `cli/calls.py` sub-app wired into `main.py`.

## Testing
6 unit tests via typer `CliRunner` + a fake client (list filters forwarded, get/transcript/recording rendering, empty cases). Verified live against prod (`calls list/get/transcript/recording`). Full custom suite: 62 passed. `verify.py` static gates pass.

Part of 5.4.0.