### PR TITLE
fix(atoms): AgentTools writes tools via the branch flow (not legacy doc)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,12 +3,13 @@
 Configure agent tools (transfer_call, end_call, ...) from code.
 
 * **`atoms.helpers.AgentTools`**: new helper to read and write a single-prompt
-  agent's tools by agentId. It read-modify-writes, so the prompt and existing
-  tools are never wiped, and it targets the deployed write path (the versioned
-  drafts API is not reachable on the public host yet). `add_transfer_call(...)`
-  configures a transfer, including `on_hold_music` so the caller hears audio while
-  the transfer bridges instead of silence. Optional-None fields are stripped from
-  the payload (the API rejects nulls), and API error bodies are surfaced on failure.
+  agent's tools by agentId, through the branch/revision versioning flow
+  (draft -> publish -> make-live) so the change actually takes effect on live
+  calls. Config is section-based, so the prompt and other tools are preserved
+  (never wiped). `add_transfer_call(...)` configures a transfer, including
+  `on_hold_music` so the caller hears audio while the transfer bridges instead of
+  silence; `make_live=False` stages a revision without activating it. Optional-None
+  fields are stripped (the API rejects nulls), and API error bodies are surfaced.
 * Re-exported `Tool`, `SinglePromptConfig`, and `ToolTransferOption` from
   `smallestai.atoms.helpers` (they are not exported from `atoms.types`).
 * **crew**: `SDKAgentTransferConversationEvent.on_hold_music` is now optional

--- a/src/smallestai/atoms/helpers/agent_tools.py
+++ b/src/smallestai/atoms/helpers/agent_tools.py
@@ -1,29 +1,23 @@
 """
 Configure agent tools (transfer_call, end_call, api_call, ...) from code.
 
-Why this helper exists
-----------------------
-Setting tools on a single-prompt agent from code is possible today, but the raw
-surface has three footguns that make it feel impossible:
+How agent config works now
+--------------------------
+Atoms runs on the **branch/revision** versioning model. Serving reads the live
+branch's head revision, so tool/prompt edits must go through the branch flow:
 
-* The versioned drafts API (``POST /agent/{id}/drafts/...``) is not reachable on
-  the public API host (it returns 404). The deployed write path is the legacy
-  workflow document.
-* That write path is ``PATCH /workflow/{workflowId}`` — it takes the *workflowId*
-  (``agent.workflowId``), not the agentId, and it does not merge: a partial
-  payload silently wipes the prompt and any tools you did not resend.
-* The wire fields are camelCase aliases (``transferNumber``, ``onHoldMusic``, ...),
-  easy to get wrong by hand.
+    PUT   /agent/{id}/branches/{branchId}/draft            (open/patch a draft)
+    POST  /agent/{id}/branches/{branchId}/draft/publish    (commit; security scan)
+    POST  /agent/{id}/branches/{branchId}/live             (make committed revision live)
 
-``AgentTools`` wraps all of that. You address agents by *agentId*, it always
-read-modify-writes (so the prompt and existing tools are never wiped), and you
-pass typed :class:`~smallestai.atoms.types.tool.Tool` models.
+Writing the legacy workflow document (``PATCH /workflow/{id}``) does **not** take
+effect on live calls under this model - serving ignores it. The v1
+drafts/versions endpoints are deprecated and return 409.
 
-Caveat: this writes the legacy workflow document directly. On an agent that is
-actively using the versioning system, a later version activation can overwrite
-the legacy doc. On the public API today versioning is not reachable, so the
-legacy doc is authoritative — but if you adopt drafts/versioning later, move tool
-edits into that flow.
+``AgentTools`` wraps the whole branch flow. You address agents by *agentId*; it
+resolves the live branch, merges tools into a draft (config is section-based, so
+your prompt is never touched), publishes, waits for the security scan, and makes
+the revision live.
 
 Usage
 -----
@@ -31,7 +25,7 @@ Usage
 
     tools = AgentTools(api_key="sk_...")           # or SMALLEST_API_KEY env var
 
-    # add a transfer-to-human tool (merges, keeps prompt + other tools)
+    # add a transfer-to-human tool and make it live (merges, keeps prompt + other tools)
     tools.add_transfer_call(
         "AGENT_ID",
         number="+15551234567",
@@ -43,12 +37,16 @@ Usage
     for t in tools.get_tools("AGENT_ID"):
         print(t.type, t.name)
     tools.remove_tool("AGENT_ID", "transfer_call")
+
+    # stage without going live (leaves a published revision you activate later)
+    tools.add_transfer_call("AGENT_ID", number="+1555...", make_live=False)
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -64,11 +62,12 @@ ToolInput = Union[Tool, Dict[str, Any]]
 
 
 class AgentToolsError(Exception):
-    """An agent could not be configured for tools (missing workflowId, wrong type, ...)."""
+    """An agent could not be configured for tools (no branch, publish failed, ...)."""
 
 
 class AgentTools:
-    """Read-modify-write tool configuration for single-prompt agents.
+    """Read-modify-write tool configuration for single-prompt agents, via the
+    branch/revision versioning flow.
 
     Can be used standalone::
 
@@ -85,69 +84,84 @@ class AgentTools:
         base_url: Optional[str] = None,
         *,
         request_timeout: float = 30.0,
+        publish_timeout: float = 120.0,
+        poll_interval: float = 3.0,
     ):
         self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
         self.base_url = (base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)).rstrip("/")
         self.request_timeout = request_timeout
+        self.publish_timeout = publish_timeout
+        self.poll_interval = poll_interval
 
     # ------------------------------------------------------------------ transport
     def _headers(self) -> Dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
 
-    def _unwrap(self, body: Any) -> Any:
-        # Atoms wraps successful reads as {"status": true, "data": {...}}.
-        if isinstance(body, dict) and "data" in body:
-            return body["data"]
-        return body
-
     def _raise_for_status(self, resp: "requests.Response", method: str, path: str) -> None:
         if resp.status_code < 400:
             return
-        # Surface the API's error body — a bare HTTPError hides why the write failed.
         try:
             detail = resp.json()
         except ValueError:
             detail = (resp.text or "")[:300]
         raise AgentToolsError(f"{method} {path} -> HTTP {resp.status_code}: {detail}")
 
+    def _unwrap(self, body: Any) -> Any:
+        if isinstance(body, dict) and "data" in body:
+            return body["data"]
+        return body
+
     def _get(self, path: str) -> Any:
         resp = requests.get(f"{self.base_url}/{path}", headers=self._headers(), timeout=self.request_timeout)
         self._raise_for_status(resp, "GET", path)
         return self._unwrap(resp.json())
 
-    def _patch(self, path: str, json_body: Dict[str, Any]) -> Any:
-        resp = requests.patch(
+    def _put(self, path: str, json_body: Dict[str, Any]) -> Any:
+        resp = requests.put(
             f"{self.base_url}/{path}", headers=self._headers(), json=json_body, timeout=self.request_timeout
         )
-        self._raise_for_status(resp, "PATCH", path)
-        return resp.json()
+        self._raise_for_status(resp, "PUT", path)
+        return self._unwrap(resp.json())
 
-    # ------------------------------------------------------------- config resolution
-    def _agent_doc(self, agent_id: str) -> Dict[str, Any]:
-        doc = self._get(f"agent/{agent_id}")
-        if not isinstance(doc, dict):
-            raise AgentToolsError(f"unexpected agent document for {agent_id!r}: {type(doc).__name__}")
-        return doc
+    def _post(self, path: str, json_body: Dict[str, Any]) -> "requests.Response":
+        resp = requests.post(
+            f"{self.base_url}/{path}", headers=self._headers(), json=json_body, timeout=self.request_timeout
+        )
+        self._raise_for_status(resp, "POST", path)
+        return resp
 
-    def _workflow_id(self, agent_id: str) -> str:
-        doc = self._agent_doc(agent_id)
-        workflow_id = doc.get("workflowId") or doc.get("workflow_id")
-        if not workflow_id:
-            raise AgentToolsError(
-                f"agent {agent_id!r} has no workflowId; cannot configure tools on it"
-            )
-        workflow_type = doc.get("workflowType") or doc.get("workflow_type") or "single_prompt"
-        if workflow_type != "single_prompt":
-            raise AgentToolsError(
-                f"agent {agent_id!r} is workflow_type={workflow_type!r}; AgentTools only "
-                "configures single_prompt agents. For workflow_graph agents, tools live on "
-                "the graph's transfer_call / api_call nodes."
-            )
-        return workflow_id
+    # ------------------------------------------------------------- branch resolution
+    def _live_branch(self, agent_id: str) -> Dict[str, Any]:
+        data = self._get(f"agent/{agent_id}/branches")
+        entries = (data or {}).get("branches") or []
+        if not entries:
+            raise AgentToolsError(f"agent {agent_id!r} has no branches; cannot configure tools")
+        for entry in entries:
+            if entry.get("isLive"):
+                return entry["branch"]
+        for entry in entries:
+            if (entry.get("branch") or {}).get("isDefault"):
+                return entry["branch"]
+        return entries[0]["branch"]
 
-    def _workflow_config(self, agent_id: str) -> Dict[str, Any]:
-        cfg = self._get(f"agent/{agent_id}/workflow")
-        return cfg if isinstance(cfg, dict) else {}
+    def _branch_by_id(self, agent_id: str, branch_id: str) -> Dict[str, Any]:
+        data = self._get(f"agent/{agent_id}/branches")
+        for entry in (data or {}).get("branches") or []:
+            branch = entry.get("branch") or {}
+            if branch.get("_id") == branch_id:
+                return branch
+        raise AgentToolsError(f"branch {branch_id!r} not found on agent {agent_id!r}")
+
+    def _resolved_config(self, agent_id: str, branch: Dict[str, Any]) -> Dict[str, Any]:
+        head = branch.get("headRevisionId")
+        if not head:
+            return {}
+        rev = self._get(f"agent/{agent_id}/branches/{branch['_id']}/revisions/{head}")
+        return (rev or {}).get("resolvedConfig", {}) or {}
+
+    @staticmethod
+    def _tools_from_config(resolved_config: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return list((resolved_config.get("workflow_tools") or {}).get("tools") or [])
 
     # ------------------------------------------------------------------ serialization
     @staticmethod
@@ -158,28 +172,53 @@ class AgentTools:
             wire = dict(tool)
         else:
             raise AgentToolsError(f"tool must be a Tool or dict, got {type(tool).__name__}")
-        # Fern's exclude_none does NOT drop fields that were explicitly set to None
-        # (e.g. Tool(transfer_only_if_human=None)), and the API rejects nulls on
-        # optional fields ("Expected boolean, received null"). Strip them here.
+        # Fern's exclude_none does NOT drop fields explicitly set to None, and the
+        # API rejects nulls on optional fields ("Expected boolean, received null").
         return {k: v for k, v in wire.items() if v is not None}
 
     @staticmethod
     def _tool_name(tool_dict: Dict[str, Any]) -> Optional[str]:
         return tool_dict.get("name")
 
+    # ------------------------------------------------------------------ publish flow
+    def _publish_and_wait(self, agent_id: str, branch_id: str, label: str) -> str:
+        """Publish the open draft and wait for the security scan to commit a new
+        revision. Returns the new head revision id."""
+        source_head = self._branch_by_id(agent_id, branch_id).get("headRevisionId")
+        resp = self._post(
+            f"agent/{agent_id}/branches/{branch_id}/draft/publish", {"label": label}
+        )
+        body = resp.json() if resp.content else {}
+        state = ((body or {}).get("data") or {}).get("state")
+        # 200 {state: "committed"} = synchronous; 202 {state: "scanning"} = async scan.
+        if resp.status_code == 200 and state == "committed":
+            return self._branch_by_id(agent_id, branch_id).get("headRevisionId")
+
+        deadline = time.time() + self.publish_timeout
+        while time.time() < deadline:
+            branch = self._branch_by_id(agent_id, branch_id)
+            head = branch.get("headRevisionId")
+            if head and head != source_head:
+                rev = self._get(f"agent/{agent_id}/branches/{branch_id}/revisions/{head}")
+                status = ((rev or {}).get("revision") or {}).get("status")
+                if status in ("committed", "published"):
+                    return head
+            time.sleep(self.poll_interval)
+        raise AgentToolsError(
+            f"publish for agent {agent_id!r} did not commit within {self.publish_timeout:.0f}s "
+            "(security scan may still be running or may have failed)"
+        )
+
     # ------------------------------------------------------------------ public API
     def get_tools(self, agent_id: str) -> List[Tool]:
-        """Return the agent's current tools as typed :class:`Tool` models.
-
-        Unknown/forward-compat tool shapes are returned as raw dicts rather than
-        dropped, so nothing is silently lost.
-        """
-        raw = self._workflow_config(agent_id).get("tools") or []
+        """Return the agent's current live tools as typed :class:`Tool` models."""
+        branch = self._live_branch(agent_id)
+        raw = self._tools_from_config(self._resolved_config(agent_id, branch))
         out: List[Tool] = []
         for entry in raw:
             try:
                 out.append(Tool(**entry))
-            except Exception:  # tolerate shapes the current models don't know about
+            except Exception:
                 out.append(entry)  # type: ignore[arg-type]
         return out
 
@@ -189,49 +228,57 @@ class AgentTools:
         tools: List[ToolInput],
         *,
         replace: bool = False,
+        make_live: bool = True,
+        label: str = "SDK tool update",
     ) -> List[Dict[str, Any]]:
-        """Write ``tools`` to the agent.
+        """Write ``tools`` through the branch flow (draft -> publish -> make-live).
 
-        Default is a merge keyed by tool ``name`` (incoming tools overwrite an
-        existing tool of the same name; other existing tools and the prompt are
-        preserved). ``replace=True`` overwrites the whole tool list.
+        Default merges by tool ``name`` (incoming overwrite same-named tools; other
+        tools and the prompt are preserved - config is section-based). ``replace=True``
+        overwrites the whole tool list. ``make_live=False`` publishes a revision but
+        does not activate it.
 
         Returns the tool list (wire dicts) that was written.
         """
-        workflow_id = self._workflow_id(agent_id)
-        cfg = self._workflow_config(agent_id)
-        prompt = cfg.get("prompt") or ""
+        branch = self._live_branch(agent_id)
+        branch_id = branch["_id"]
         incoming = [self._to_wire(t) for t in tools]
 
         if replace:
             merged = incoming
         else:
             by_name: Dict[Optional[str], Dict[str, Any]] = {}
-            for existing in cfg.get("tools") or []:
+            for existing in self._tools_from_config(self._resolved_config(agent_id, branch)):
                 by_name[self._tool_name(existing)] = existing
             for tool in incoming:
                 by_name[self._tool_name(tool)] = tool
             merged = list(by_name.values())
 
         logger.info(
-            "AgentTools.set_tools agent=%s workflow=%s tools=%s replace=%s",
-            agent_id,
-            workflow_id,
-            [self._tool_name(t) for t in merged],
-            replace,
+            "AgentTools.set_tools agent=%s branch=%s tools=%s replace=%s make_live=%s",
+            agent_id, branch_id, [self._tool_name(t) for t in merged], replace, make_live,
         )
-        self._patch(
-            f"workflow/{workflow_id}",
-            {"type": "single_prompt", "singlePromptConfig": {"prompt": prompt, "tools": merged}},
+        self._put(
+            f"agent/{agent_id}/branches/{branch_id}/draft",
+            {"singlePromptConfig": {"tools": merged}},
         )
-        logger.info("AgentTools.set_tools OK agent=%s wrote %d tool(s)", agent_id, len(merged))
+        self._publish_and_wait(agent_id, branch_id, label)
+        logger.info("AgentTools.set_tools published agent=%s", agent_id)
+        if make_live:
+            self._post(f"agent/{agent_id}/branches/{branch_id}/live", {})
+            logger.info("AgentTools.set_tools made live agent=%s (%d tool(s))", agent_id, len(merged))
         return merged
 
-    def remove_tool(self, agent_id: str, name: str) -> List[Dict[str, Any]]:
+    def remove_tool(self, agent_id: str, name: str, *, make_live: bool = True) -> List[Dict[str, Any]]:
         """Remove the tool with the given ``name`` (no-op if absent)."""
-        kept = [t for t in (self._workflow_config(agent_id).get("tools") or []) if self._tool_name(t) != name]
+        branch = self._live_branch(agent_id)
+        kept = [
+            t
+            for t in self._tools_from_config(self._resolved_config(agent_id, branch))
+            if self._tool_name(t) != name
+        ]
         logger.info("AgentTools.remove_tool agent=%s name=%s", agent_id, name)
-        return self.set_tools(agent_id, kept, replace=True)  # type: ignore[arg-type]
+        return self.set_tools(agent_id, kept, replace=True, make_live=make_live, label=f"remove {name}")  # type: ignore[arg-type]
 
     def add_transfer_call(
         self,
@@ -244,6 +291,7 @@ class AgentTools:
         on_hold_music: Optional[str] = None,
         transfer_only_if_human: Optional[bool] = None,
         enabled: bool = True,
+        make_live: bool = True,
         **extra: Any,
     ) -> Tool:
         """Add a ``transfer_call`` tool that forwards the call to ``number``.
@@ -253,20 +301,19 @@ class AgentTools:
         number : str
             E.164 destination, e.g. ``"+15551234567"``.
         transfer_type : str
-            ``"cold_transfer"`` (hang up on connect) or ``"warm_transfer"``.
+            ``"cold_transfer"`` (blind) or ``"warm_transfer"``.
         on_hold_music : str, optional
             Audio played to the caller while the transfer bridges, so the line is
             not silent. One of ``"ringtone"``, ``"relaxing_sound"``,
             ``"uplifting_beats"``, ``"none"``.
         transfer_only_if_human : bool, optional
             Only transfer if a human (not voicemail) answers the destination.
+        make_live : bool
+            Publish and activate immediately (default). ``False`` stages it.
 
         The tool is merged into the agent's existing tools; the prompt and other
         tools are preserved. Returns the :class:`Tool` that was written.
         """
-        # Only pass optionals that have a value — the API rejects explicit nulls,
-        # and tool descriptions are restricted to a limited charset (no '+', so the
-        # default cannot embed the E.164 number).
         kwargs: Dict[str, Any] = dict(
             type="transfer_call",
             name=name,
@@ -282,5 +329,5 @@ class AgentTools:
             kwargs["transfer_only_if_human"] = transfer_only_if_human
         kwargs.update(extra)
         tool = Tool(**kwargs)
-        self.set_tools(agent_id, [tool])
+        self.set_tools(agent_id, [tool], make_live=make_live, label="add transfer_call")
         return tool

--- a/tests/custom/test_agent_tools_helper.py
+++ b/tests/custom/test_agent_tools_helper.py
@@ -1,11 +1,11 @@
-"""Unit tests for the AgentTools helper.
+"""Unit tests for the AgentTools helper (branch/revision versioning flow).
 
-These exercise the read-modify-write logic with a fake transport (no network):
-- merge vs replace semantics keyed by tool name
-- prompt + other tools are preserved (never wiped)
-- the write targets PATCH /workflow/{workflowId} with camelCase wire fields
+Exercised with a fake transport (no network):
+- merge vs replace semantics keyed by tool name, over the live resolved config
+- the write goes through the branch flow: PUT draft -> publish -> make-live
+- the draft body carries singlePromptConfig.tools with camelCase wire fields
 - add_transfer_call builds a correct transfer_call Tool (incl. on_hold_music)
-- guardrails: missing workflowId and non-single_prompt agents raise
+- None optionals are stripped; API error bodies are surfaced
 """
 
 import json
@@ -20,9 +20,11 @@ from smallestai.atoms.helpers import (
     ToolTransferOption,
 )
 
+BRANCH_ID = "BR1"
+HEAD = "REV1"
+
 
 def test_exported_tool_models_construct_and_serialize():
-    """The models re-exported from atoms.helpers build and serialize by alias."""
     option = ToolTransferOption(type="warm_transfer")
     tool = Tool(
         type="transfer_call",
@@ -43,176 +45,158 @@ class FakeResponse:
         self._payload = payload
         self.status_code = status_code
         self.text = json.dumps(payload)
+        self.content = self.text.encode()
 
     def json(self):
         return self._payload
 
 
-class FakeTransport:
-    """Records GET/PATCH calls and serves canned agent + workflow docs."""
+class FakeBranchTransport:
+    """Serves the branch endpoints and records draft/publish/live calls."""
 
-    def __init__(self, agent_doc, workflow_cfg):
-        self.agent_doc = agent_doc
-        self.workflow_cfg = workflow_cfg
-        self.patches = []  # (path, body)
-        self.gets = []
+    def __init__(self, tools):
+        self.resolved_tools = list(tools)  # current live tools
+        self.puts = []       # (url, body)
+        self.published = 0
+        self.made_live = 0
 
+    # GET /agent/{id}/branches  and  /branches/{bid}/revisions/{head}
     def get(self, url, headers=None, timeout=None):
-        self.gets.append(url)
-        if url.endswith("/workflow"):
-            return FakeResponse({"status": True, "data": self.workflow_cfg})
-        return FakeResponse({"status": True, "data": self.agent_doc})
+        if url.endswith("/branches"):
+            return FakeResponse({"data": {"branches": [{
+                "isLive": True,
+                "branch": {"_id": BRANCH_ID, "name": "main", "isDefault": True,
+                           "status": "active", "headRevisionId": HEAD},
+            }]}})
+        if "/revisions/" in url:
+            return FakeResponse({"data": {
+                "revision": {"status": "published"},
+                "resolvedConfig": {"workflow_tools": {"tools": self.resolved_tools}},
+            }})
+        return FakeResponse({"data": {}})
 
-    def patch(self, url, headers=None, json=None, timeout=None):
-        self.patches.append((url, json))
-        # reflect the write into the stored config so a subsequent read sees it
-        self.workflow_cfg = dict(self.workflow_cfg)
-        self.workflow_cfg["tools"] = json["singlePromptConfig"]["tools"]
-        return FakeResponse({"status": True, "data": self.workflow_cfg})
+    def put(self, url, headers=None, json=None, timeout=None):
+        self.puts.append((url, json))
+        # reflect the draft tools into the "live" config so publish->live is visible
+        self.resolved_tools = json["singlePromptConfig"]["tools"]
+        return FakeResponse({"data": {"draftId": "D1"}})
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        if url.endswith("/draft/publish"):
+            self.published += 1
+            return FakeResponse({"data": {"state": "committed"}})  # sync commit, no poll
+        if url.endswith("/live"):
+            self.made_live += 1
+            return FakeResponse({"data": {"branch": {"_id": BRANCH_ID}}})
+        return FakeResponse({"data": {}})
 
 
 @pytest.fixture
 def wired(monkeypatch):
-    def _make(agent_doc, workflow_cfg):
-        transport = FakeTransport(agent_doc, workflow_cfg)
-        monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.get", transport.get)
-        monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.patch", transport.patch)
-        helper = AgentTools(api_key="sk_test", base_url="https://api.example/atoms/v1")
-        return helper, transport
+    def _make(tools):
+        t = FakeBranchTransport(tools)
+        monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.get", t.get)
+        monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.put", t.put)
+        monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.post", t.post)
+        return AgentTools(api_key="sk_test", base_url="https://api.example/atoms/v1"), t
 
     return _make
 
 
-AGENT_DOC = {"_id": "AG1", "workflowId": "WF1", "workflowType": "single_prompt"}
-
-
-def test_add_transfer_call_builds_correct_tool_and_targets_workflow(wired):
-    helper, t = wired(AGENT_DOC, {"prompt": "You are helpful.", "tools": []})
+def test_add_transfer_call_runs_full_branch_flow(wired):
+    helper, t = wired([])
     tool = helper.add_transfer_call(
         "AG1", number="+15551234567", transfer_type="cold_transfer", on_hold_music="relaxing_sound"
     )
     assert isinstance(tool, Tool)
-    assert tool.transfer_number == "+15551234567"
-
-    # one PATCH, to the workflowId (not the agentId), single_prompt shape
-    assert len(t.patches) == 1
-    url, body = t.patches[0]
-    assert url.endswith("/workflow/WF1")
-    assert body["type"] == "single_prompt"
-    written = body["singlePromptConfig"]["tools"]
-    assert len(written) == 1
-    wire = written[0]
-    # camelCase aliases on the wire
+    # draft -> publish -> make-live all happened, once
+    assert len(t.puts) == 1
+    assert t.published == 1
+    assert t.made_live == 1
+    url, body = t.puts[0]
+    assert url.endswith(f"/branches/{BRANCH_ID}/draft")
+    wire = body["singlePromptConfig"]["tools"][0]
     assert wire["type"] == "transfer_call"
     assert wire["transferNumber"] == "+15551234567"
     assert wire["transferOption"] == {"type": "cold_transfer"}
     assert wire["onHoldMusic"] == "relaxing_sound"
-    # prompt preserved
-    assert body["singlePromptConfig"]["prompt"] == "You are helpful."
 
 
-def test_none_optionals_are_stripped_from_wire(wired):
-    """Explicit-None optionals must not reach the API (it rejects nulls)."""
-    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": []})
-    # transfer_only_if_human omitted -> must be absent, not null
-    helper.add_transfer_call("AG1", number="+15551234567")
-    _, body = t.patches[0]
-    wire = body["singlePromptConfig"]["tools"][0]
-    assert "transferOnlyIfHuman" not in wire
-    assert "onHoldMusic" not in wire
-    # default description must be within the allowed charset (no '+')
-    assert "+" not in wire["description"]
+def test_merge_preserves_existing_live_tools(wired):
+    helper, t = wired([{"type": "end_call", "name": "end_call", "description": "bye"}])
+    helper.add_transfer_call("AG1", number="+1")
+    _, body = t.puts[0]
+    names = [x["name"] for x in body["singlePromptConfig"]["tools"]]
+    assert names == ["end_call", "transfer_call"]
 
 
-def test_user_tool_with_explicit_none_is_stripped(wired):
-    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": []})
-    tool = Tool(type="transfer_call", name="x", description="d", transfer_number="+1", transfer_only_if_human=None)
-    helper.set_tools("AG1", [tool])
-    _, body = t.patches[0]
-    assert "transferOnlyIfHuman" not in body["singlePromptConfig"]["tools"][0]
-
-
-def test_set_tools_merges_by_name_and_preserves_existing(wired):
-    existing = {"type": "end_call", "name": "end_call", "description": "bye", "enabled": True}
-    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": [existing]})
-    new_tool = Tool(type="transfer_call", name="transfer_call", description="d", transfer_number="+1")
-    helper.set_tools("AG1", [new_tool])
-
-    _, body = t.patches[0]
-    names = [tool["name"] for tool in body["singlePromptConfig"]["tools"]]
-    assert names == ["end_call", "transfer_call"]  # existing kept, new appended
-
-
-def test_set_tools_same_name_overwrites_not_duplicates(wired):
-    existing = {"type": "transfer_call", "name": "transfer_call", "transferNumber": "+1old"}
-    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": [existing]})
+def test_same_name_overwrites(wired):
+    helper, t = wired([{"type": "transfer_call", "name": "transfer_call", "transferNumber": "+1old"}])
     helper.add_transfer_call("AG1", number="+1new")
-
-    _, body = t.patches[0]
+    _, body = t.puts[0]
     tools = body["singlePromptConfig"]["tools"]
-    assert len(tools) == 1
-    assert tools[0]["transferNumber"] == "+1new"
+    assert len(tools) == 1 and tools[0]["transferNumber"] == "+1new"
 
 
-def test_set_tools_replace_overwrites_all(wired):
-    existing = {"type": "end_call", "name": "end_call"}
-    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": [existing]})
+def test_replace_overwrites_all(wired):
+    helper, t = wired([{"type": "end_call", "name": "end_call"}])
     helper.set_tools("AG1", [Tool(type="transfer_call", name="x", description="d", transfer_number="+1")], replace=True)
-
-    _, body = t.patches[0]
-    names = [tool["name"] for tool in body["singlePromptConfig"]["tools"]]
-    assert names == ["x"]  # end_call dropped
+    _, body = t.puts[0]
+    assert [x["name"] for x in body["singlePromptConfig"]["tools"]] == ["x"]
 
 
 def test_remove_tool(wired):
-    tools = [
+    helper, t = wired([
         {"type": "transfer_call", "name": "transfer_call"},
         {"type": "end_call", "name": "end_call"},
-    ]
-    helper, t = wired(AGENT_DOC, {"prompt": "P", "tools": tools})
+    ])
     helper.remove_tool("AG1", "transfer_call")
-
-    _, body = t.patches[0]
-    names = [tool["name"] for tool in body["singlePromptConfig"]["tools"]]
-    assert names == ["end_call"]
+    _, body = t.puts[0]
+    assert [x["name"] for x in body["singlePromptConfig"]["tools"]] == ["end_call"]
 
 
-def test_get_tools_returns_typed(wired):
-    tools = [{"type": "transfer_call", "name": "transfer_call", "description": "d", "transferNumber": "+1"}]
-    helper, _ = wired(AGENT_DOC, {"prompt": "P", "tools": tools})
+def test_make_live_false_publishes_but_does_not_activate(wired):
+    helper, t = wired([])
+    helper.add_transfer_call("AG1", number="+1", make_live=False)
+    assert t.published == 1
+    assert t.made_live == 0
+
+
+def test_get_tools_reads_live_resolved_config(wired):
+    helper, _ = wired([{"type": "transfer_call", "name": "transfer_call", "description": "d", "transferNumber": "+1"}])
     got = helper.get_tools("AG1")
-    assert len(got) == 1
-    assert isinstance(got[0], Tool)
+    assert len(got) == 1 and isinstance(got[0], Tool)
     assert got[0].transfer_number == "+1"
 
 
-def test_missing_workflow_id_raises(wired):
-    helper, _ = wired({"_id": "AG1", "workflowType": "single_prompt"}, {"prompt": "P", "tools": []})
-    with pytest.raises(AgentToolsError, match="no workflowId"):
-        helper.set_tools("AG1", [Tool(type="end_call", name="end_call", description="d")])
+def test_none_optionals_stripped_from_wire(wired):
+    helper, t = wired([])
+    helper.add_transfer_call("AG1", number="+15551234567")
+    wire = t.puts[0][1]["singlePromptConfig"]["tools"][0]
+    assert "transferOnlyIfHuman" not in wire
+    assert "onHoldMusic" not in wire
+    assert "+" not in wire["description"]
 
 
-def test_non_single_prompt_agent_raises(wired):
-    helper, _ = wired(
-        {"_id": "AG1", "workflowId": "WF1", "workflowType": "workflow_graph"}, {"prompt": "P", "tools": []}
-    )
-    with pytest.raises(AgentToolsError, match="workflow_graph"):
+def test_no_branches_raises(monkeypatch):
+    def empty_get(url, headers=None, timeout=None):
+        return FakeResponse({"data": {"branches": []}})
+
+    monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.get", empty_get)
+    helper = AgentTools(api_key="sk_test", base_url="https://api.example/atoms/v1")
+    with pytest.raises(AgentToolsError, match="no branches"):
         helper.add_transfer_call("AG1", number="+1")
 
 
 def test_api_error_body_is_surfaced(monkeypatch):
-    """A non-2xx write raises AgentToolsError carrying the API's error body."""
+    def get(url, headers=None, timeout=None):
+        return FakeResponse({"data": {"branches": [{"isLive": True, "branch": {"_id": BRANCH_ID, "headRevisionId": HEAD, "isDefault": True}}]}})
 
-    def bad_patch(url, headers=None, json=None, timeout=None):
-        return FakeResponse({"status": False, "error": "prompt is required"}, status_code=400)
+    def bad_put(url, headers=None, json=None, timeout=None):
+        return FakeResponse({"status": False, "errors": ["invalid tool"]}, status_code=400)
 
-    def ok_get(url, headers=None, timeout=None):
-        if url.endswith("/workflow"):
-            return FakeResponse({"data": {"prompt": "P", "tools": []}})
-        return FakeResponse({"data": AGENT_DOC})
-
-    monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.get", ok_get)
-    monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.patch", bad_patch)
+    monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.get", get)
+    monkeypatch.setattr("smallestai.atoms.helpers.agent_tools.requests.put", bad_put)
     helper = AgentTools(api_key="sk_test", base_url="https://api.example/atoms/v1")
-    with pytest.raises(AgentToolsError, match="HTTP 400.*prompt is required"):
+    with pytest.raises(AgentToolsError, match="HTTP 400.*invalid tool"):
         helper.add_transfer_call("AG1", number="+1")


### PR DESCRIPTION
## What
Rewrites `AgentTools` (from #72) to configure tools through the **branch/revision** versioning flow instead of the legacy workflow doc.

## Why this was broken
#72 wrote `PATCH /workflow/{id}` (the legacy workflow document). The branch/revision model is now live in prod (`ENABLE_BRANCH_MODEL`), and **serving reads the live branch's head revision — it ignores the legacy doc.** So SDK-set tools persisted but never fired. Verified live: an agent configured the old way answered *"I can't transfer calls."*

The v1 drafts/versions endpoints that used to accept tools are deprecated (409) and get removed at T+7 (per PRO-1789), so the branch API is the only correct path.

## How
`set_tools` now:
1. resolves the live branch (`GET /agent/{id}/branches`, `isLive`)
2. reads current tools from `resolvedConfig.workflow_tools.tools`, merges by name
3. `PUT /agent/{id}/branches/{branchId}/draft` with `singlePromptConfig.tools` (config is **section-based**, so the prompt/other sections are untouched — no wipe)
4. `POST .../draft/publish` and waits for the security scan to commit
5. `POST .../live` to activate (skippable with `make_live=False`)

## Verified live (prod)
- `add_transfer_call` → tool lands in `resolvedConfig.workflow_tools.tools` with the right number + `onHoldMusic`, merged with the existing `end_call`.
- A real call to an agent configured this way **transfers**: the agent said *"I'll transfer your call to a specialist now"* and the destination agent received the bridged leg.

## Testing
11 unit tests over a fake branch transport (draft→publish→make-live, merge/replace, remove, `make_live=False`, None-stripping, error surfacing, no-branches guard). `verify.py` gates pass.

Supersedes the write path in #72. Part of 5.4.0.