### PR TITLE
fix(crew): seed context from LLM-request messages (unbreak silent agent)

### DIFF
--- a/src/smallestai/atoms/crew/context.py
+++ b/src/smallestai/atoms/crew/context.py
@@ -14,3 +14,8 @@ class ContextManager:
 
     def add_messages(self, messages: List[Dict[str, Any]]):
         self._messages.extend(messages)
+
+    def set_messages(self, messages: List[Dict[str, Any]]):
+        """Replace the whole message list (e.g. sync to the platform's
+        authoritative conversation carried on an LLM-request event)."""
+        self._messages = list(messages)

--- a/src/smallestai/atoms/crew/events.py
+++ b/src/smallestai/atoms/crew/events.py
@@ -245,8 +245,14 @@ class SDKSystemUserStoppedSpeakingEvent(
 
 
 class SDKSystemLLMRequestEvent(SDKSystemEvent, type=EventType.SYSTEM_LLM_REQUEST.value):
-    """Request to LLM for completion."""
+    """Request to LLM for completion.
 
+    ``messages`` carries the platform's authoritative conversation (system + user
+    + assistant turns) for this request. It is the reliable source of the current
+    context — prefer it over separately-accumulated transcript state.
+    """
+
+    messages: Optional[List[Dict[str, Any]]] = None
     extra_params: Dict[str, Any] = Field(default_factory=dict)
 
 

--- a/src/smallestai/atoms/crew/nodes/output_crew.py
+++ b/src/smallestai/atoms/crew/nodes/output_crew.py
@@ -80,6 +80,23 @@ class OutputCrewNode(CrewNode):
         `on_event` override, so a subclass can't accidentally silence the agent
         (e.g. by dropping the LLM-request -> generate_response path)."""
         if isinstance(event, SDKSystemLLMRequestEvent):
+            # The LLM-request event carries the platform's authoritative message
+            # list. Sync the user/assistant conversation from it so
+            # generate_response always sees the latest user turn, instead of
+            # relying only on separately-accumulated transcript events — those can
+            # race the request or be dropped, leaving the context empty (Claude
+            # then 400s on "no non-system message" and the agent goes silent).
+            #
+            # The node's own system prompt(s) are preserved: a crew sets its system
+            # message in code (self.context.add_message), and the platform's list
+            # may not carry it. Fall back to the accumulated context when a request
+            # carries no messages.
+            if event.messages:
+                system_msgs = [m for m in self.context.messages if m.get("role") == "system"]
+                if not system_msgs:
+                    system_msgs = [m for m in event.messages if m.get("role") == "system"]
+                conversation = [m for m in event.messages if m.get("role") != "system"]
+                self.context.set_messages(system_msgs + conversation)
             await self._handle_llm_request()
         elif isinstance(event, SDKAgentTranscriptUpdateEvent):
             self.context.add_message({"role": event.role, "content": event.content})

--- a/src/smallestai/atoms/crew/nodes/output_crew.py
+++ b/src/smallestai/atoms/crew/nodes/output_crew.py
@@ -96,7 +96,12 @@ class OutputCrewNode(CrewNode):
                 if not system_msgs:
                     system_msgs = [m for m in event.messages if m.get("role") == "system"]
                 conversation = [m for m in event.messages if m.get("role") != "system"]
-                self.context.set_messages(system_msgs + conversation)
+                # Only sync when the request actually carries a conversation. If it
+                # carries only a system message (or is otherwise empty of turns),
+                # keep the accumulated context rather than shipping a system-only
+                # list, which would re-introduce the "no non-system message" 400.
+                if conversation:
+                    self.context.set_messages(system_msgs + conversation)
             await self._handle_llm_request()
         elif isinstance(event, SDKAgentTranscriptUpdateEvent):
             self.context.add_message({"role": event.role, "content": event.content})

--- a/tests/custom/test_crew_context_from_llm_request.py
+++ b/tests/custom/test_crew_context_from_llm_request.py
@@ -1,0 +1,84 @@
+"""OutputCrewNode must seed its context from the LLM-request event's messages.
+
+Regression: the crew relied only on separately-accumulated transcript events to
+populate self.context. When those raced the LLM request or were dropped, the
+context was empty, Claude 400'd ("no non-system message"), and the agent went
+silent for the whole call. The LLM-request event carries the platform's
+authoritative message list, so we seed the context from it before generating.
+"""
+import unittest
+from unittest import mock
+
+from smallestai.atoms.crew.nodes import OutputCrewNode
+from smallestai.atoms.crew.events import SDKSystemLLMRequestEvent, SDKAgentTranscriptUpdateEvent
+
+
+class _Agent(OutputCrewNode):
+    def __init__(self):
+        super().__init__(name="a")
+
+    async def generate_response(self):
+        if False:
+            yield ""
+
+
+class ContextFromLLMRequestTest(unittest.IsolatedAsyncioTestCase):
+    async def test_context_seeded_from_event_messages(self):
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "transfer me to a human"},
+        ]
+        await agent.process_event(SDKSystemLLMRequestEvent(messages=msgs))
+        # generate_response would now see the authoritative context, incl. the user turn
+        assert agent.context.messages == msgs
+
+    async def test_empty_context_is_populated_before_generation(self):
+        """The exact silence bug: no transcript events arrived, but the request
+        carries the messages, so the context is non-empty when we generate."""
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        seen = {}
+
+        async def fake_handle():
+            seen["had_user"] = any(m.get("role") == "user" for m in agent.context.messages)
+
+        agent._handle_llm_request = fake_handle
+        await agent.process_event(
+            SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "hi"}])
+        )
+        assert seen["had_user"] is True
+
+    async def test_no_messages_falls_back_to_accumulated_context(self):
+        """Backward compat: a request without messages leaves accumulated context intact."""
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        await agent.process_event(SDKAgentTranscriptUpdateEvent(role="user", content="hello"))
+        await agent.process_event(SDKSystemLLMRequestEvent())  # no messages
+        assert agent.context.messages == [{"role": "user", "content": "hello"}]
+
+    async def test_node_system_prompt_is_preserved(self):
+        """A crew sets its system prompt in code; syncing from the event must keep it."""
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        agent.context.add_message({"role": "system", "content": "CREW SYSTEM PROMPT"})
+        await agent.process_event(
+            SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "hi"}])
+        )
+        assert agent.context.messages == [
+            {"role": "system", "content": "CREW SYSTEM PROMPT"},
+            {"role": "user", "content": "hi"},
+        ]
+
+    async def test_event_messages_are_authoritative_over_stale_accumulation(self):
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        await agent.process_event(SDKAgentTranscriptUpdateEvent(role="user", content="stale"))
+        fresh = [{"role": "user", "content": "fresh authoritative turn"}]
+        await agent.process_event(SDKSystemLLMRequestEvent(messages=fresh))
+        assert agent.context.messages == fresh
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/custom/test_crew_context_from_llm_request.py
+++ b/tests/custom/test_crew_context_from_llm_request.py
@@ -80,5 +80,41 @@ class ContextFromLLMRequestTest(unittest.IsolatedAsyncioTestCase):
         assert agent.context.messages == fresh
 
 
+    async def test_empty_list_messages_keeps_accumulated_context(self):
+        """A request whose messages is [] must not wipe context to a system-only list."""
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        agent.context.add_message({"role": "system", "content": "SYS"})
+        await agent.process_event(SDKAgentTranscriptUpdateEvent(role="user", content="hello"))
+        await agent.process_event(SDKSystemLLMRequestEvent(messages=[]))
+        assert agent.context.messages == [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hello"},
+        ]
+
+    async def test_system_only_event_does_not_clobber_conversation(self):
+        """If the event carries only a system message, keep the existing conversation."""
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        agent.context.add_message({"role": "system", "content": "SYS"})
+        agent.context.add_message({"role": "user", "content": "earlier turn"})
+        await agent.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "system", "content": "S2"}]))
+        assert {"role": "user", "content": "earlier turn"} in agent.context.messages
+
+    async def test_tool_call_sequence_order_preserved(self):
+        """assistant(tool_calls) + tool(result) survive the sync in order."""
+        agent = _Agent()
+        agent.send_event = mock.AsyncMock()
+        msgs = [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "transfer me"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1", "function": {"name": "transfer_call"}}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "ok"},
+            {"role": "user", "content": "thanks"},
+        ]
+        await agent.process_event(SDKSystemLLMRequestEvent(messages=msgs))
+        assert agent.context.messages == msgs  # order + tool block intact
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
A crew agent (custom LLM, e.g. Claude) could go **silent for a whole call** — greet once, then never respond to any user turn, so it also never fires `transfer_call`. Reproduced live.

## Root cause
`OutputCrewNode` populated `self.context` **only** from separately-accumulated `SDKAgentTranscriptUpdateEvent`s. When those race the LLM request or are dropped, the context has only the system message. The custom LLM then 400s ("at least one non-system message required") and produces nothing.

pipecat already sends the platform's **authoritative message list** on `SDKSystemLLMRequestEvent` — but the SDK dropped it: `TypedModel` is a plain pydantic model (default `extra="ignore"`), so the `messages` payload was discarded.

## Fix
- Add `messages: Optional[List[Dict[str, Any]]]` to `SDKSystemLLMRequestEvent`.
- In `OutputCrewNode._route_framework_event`, when the request carries messages, **sync the user/assistant conversation** from it before `generate_response`, so the LLM always sees the latest user turn.
- **Preserve the node's own system prompt** (a crew sets its system message in code; the platform list may not carry it). Fall back to the accumulated context when a request has no messages.
- Add `ContextManager.set_messages`.

## Testing
7 unit tests pass (seeding from event, **system-prompt preservation**, authoritative-over-stale, no-messages fallback, plus the existing on_event/routing tests). `verify.py` gates pass. Live crew re-test pending (deploying the crew against this branch).

Requires no pipecat change — pipecat already sends `messages`.