### PR TITLE
docs(examples): transfer_call, crew transfer node, inspect calls

### DIFF
--- a/examples/crew_transfer_node.py
+++ b/examples/crew_transfer_node.py
@@ -31,7 +31,7 @@ from smallestai.atoms.crew.events import (
 # turns @function_tool methods into schemas; wire in whatever your crew uses.
 # (Guarded so this template file imports cleanly; replace with your real client.)
 try:
-    from your_llm import OpenAIClient, ToolRegistry, function_tool
+    from your_llm import OpenAIClient, ToolRegistry, function_tool  # type: ignore
 except ImportError:  # template placeholder
     OpenAIClient = ToolRegistry = None
 

--- a/examples/crew_transfer_node.py
+++ b/examples/crew_transfer_node.py
@@ -1,0 +1,100 @@
+"""
+Agent-crew node that transfers the call, with a custom LLM — smallestai 5.4.0.
+
+In an agent crew, a transfer is code: a node emits SDKAgentTransferConversationEvent.
+This is the node you'd ship in a crew project (server.py registers the crew and
+`smallestai agent-crew deploy` builds it). Shown with a custom LLM (any OpenAI-
+compatible endpoint — here Anthropic/Claude) to mirror a common setup.
+
+Key points this example bakes in:
+  - The node's generate_response uses self.context.messages, which the SDK now
+    seeds from the platform's authoritative LLM-request messages (5.4.0) — so the
+    agent always sees the latest user turn and doesn't go silent.
+  - The system prompt must clearly tell the LLM WHEN to call transfer_call.
+  - on_hold_music applies to warm_transfer only; cold_transfer is a direct connect.
+
+Deploy (from a project dir with this file as the node, a server.py, and a
+requirements.txt pinning smallestai>=5.4.0 plus your LLM client):
+    smallestai agent-crew deploy --entry-point server.py
+"""
+import os
+
+from smallestai.atoms.crew.nodes import OutputCrewNode
+from smallestai.atoms.crew.events import (
+    SDKAgentTransferConversationEvent,
+    TransferOption,
+    TransferOptionType,
+)
+
+# Bring your own OpenAI-compatible client + tool registry. This example assumes a
+# client exposing `.chat(messages=..., stream=True, tools=...)` and a registry that
+# turns @function_tool methods into schemas; wire in whatever your crew uses.
+# (Guarded so this template file imports cleanly; replace with your real client.)
+try:
+    from your_llm import OpenAIClient, ToolRegistry, function_tool
+except ImportError:  # template placeholder
+    OpenAIClient = ToolRegistry = None
+
+    def function_tool(name):  # type: ignore
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+TRANSFER_NUMBER = os.getenv("TRANSFER_CALL_NUMBER", "+15551234567")
+
+
+class Assistant(OutputCrewNode):
+    def __init__(self) -> None:
+        super().__init__(name="assistant")
+        self.llm = OpenAIClient(
+            model=os.getenv("CUSTOM_LLM_MODEL", "claude-haiku-4-5"),
+            api_key=os.getenv("ANTHROPIC_API_KEY"),
+            base_url=os.getenv("CUSTOM_LLM_BASE_URL", "https://api.anthropic.com/v1/"),
+        )
+        # System prompt: be explicit about when to transfer, or the tool never fires.
+        self.context.add_message(
+            {
+                "role": "system",
+                "content": (
+                    "You are Acme support. The moment the caller asks for a human, a "
+                    "person, a specialist, or to be transferred, call the transfer_call "
+                    "tool immediately. Do not keep talking — just call the tool."
+                ),
+            }
+        )
+        self.tool_registry = ToolRegistry()
+        self.tool_registry.discover(self)
+        self.tool_schemas = self.tool_registry.get_schemas()
+
+    @function_tool(name="transfer_call")
+    async def transfer_call(self) -> None:
+        """Transfer the call to a human specialist."""
+        await self.send_event(
+            SDKAgentTransferConversationEvent(
+                transfer_call_number=TRANSFER_NUMBER,
+                # cold = direct connect; use WARM_TRANSFER + on_hold_music for music.
+                transfer_options=TransferOption(type=TransferOptionType.COLD_TRANSFER),
+                # on_hold_music="relaxing_sound",  # warm transfer only
+            )
+        )
+
+    async def generate_response(self):
+        # self.context.messages is seeded from the platform's authoritative
+        # messages before this runs (5.4.0), so it always has the latest user turn.
+        response = await self.llm.chat(
+            messages=self.context.messages, stream=True, tools=self.tool_schemas
+        )
+        full = ""
+        tool_calls = []
+        async for chunk in response:
+            if chunk.content:
+                full += chunk.content
+                yield chunk.content
+            if chunk.tool_calls:
+                tool_calls.extend(chunk.tool_calls)
+        if tool_calls:
+            await self.tool_registry.execute(tool_calls=tool_calls, parallel=True)
+            return
+        if full:
+            self.context.add_message({"role": "assistant", "content": full})

--- a/examples/inspect_calls.py
+++ b/examples/inspect_calls.py
@@ -1,0 +1,51 @@
+"""
+Inspect calls: list, details, transcript, recording — smallestai 5.4.0.
+
+Read-only helpers for after a call happened. Handy for verifying a transfer:
+a transfer leg that shows status `no_answer` / `timeout` fired correctly but the
+destination did not pick up (not an SDK problem).
+
+Run:
+    pip install "smallestai>=5.4.0"
+    export SMALLEST_API_KEY=sk_...
+    python examples/inspect_calls.py            # lists recent calls
+    python examples/inspect_calls.py CALL-...   # details + transcript for one call
+"""
+import os
+import sys
+
+from smallestai import SmallestAI
+
+
+def main() -> None:
+    client = SmallestAI(api_key=os.environ["SMALLEST_API_KEY"])
+
+    if len(sys.argv) > 1:
+        call_id = sys.argv[1]
+        call = client.atoms.calls.get(id=call_id).data
+        print(f"call {call_id}")
+        print("  status     :", getattr(call, "status", None))
+        print("  type       :", getattr(call, "type", None))
+        print("  duration   :", getattr(call, "duration", None))
+        print("  from -> to :", getattr(call, "from_", None), "->", getattr(call, "to", None))
+        print("  recording  :", getattr(call, "recording_url", None))
+        print("  transcript :")
+        for turn in getattr(call, "transcript", None) or []:
+            print(f"    {getattr(turn, 'role', '?')}: {getattr(turn, 'content', '')}")
+        return
+
+    # No id given -> list recent calls.
+    logs = client.atoms.calls.list(limit=10).data.logs or []
+    print(f"{len(logs)} recent call(s):")
+    for item in logs:
+        print(
+            f"  {getattr(item, 'call_id', '?')}  "
+            f"{(getattr(item, 'type', '') or '').replace('telephony_', ''):9} "
+            f"{getattr(item, 'status', ''):10} "
+            f"{getattr(item, 'from_', '')} -> {getattr(item, 'to', '')}"
+        )
+    print("\nPass a CALL-... id to see its transcript + recording.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/transfer_call.py
+++ b/examples/transfer_call.py
@@ -1,0 +1,73 @@
+"""
+Configure a transfer_call tool on a single-prompt agent from code — smallestai 5.4.0.
+
+Uses `AgentTools`, which drives the branch/revision versioning flow
+(draft -> publish -> make-live) so the tool actually takes effect on live calls.
+Writing the legacy workflow doc does NOT take effect under the branch model.
+
+Transfer types:
+  - cold_transfer: a direct connect. The caller is bridged straight to the
+    destination, no debrief. No hold music / whisper / three-way (nothing to fill).
+  - warm_transfer: the agent debriefs the destination before bridging. This is the
+    window where on_hold_music (and whisper / three-way) apply.
+
+So: if you want the caller to hear music during the transfer, use warm_transfer.
+Setting on_hold_music on a cold transfer is silently ignored.
+
+Run:
+    pip install "smallestai>=5.4.0"
+    export SMALLEST_API_KEY=sk_...
+    python examples/transfer_call.py
+"""
+import os
+
+from smallestai import SmallestAI
+from smallestai.atoms.helpers import AgentTools
+
+
+def main() -> None:
+    api_key = os.environ["SMALLEST_API_KEY"]
+    client = SmallestAI(api_key=api_key)
+
+    # 1. A single-prompt agent. Its prompt should tell the LLM WHEN to transfer,
+    #    otherwise the tool never fires.
+    agent_id = client.atoms.agents.create_agent(
+        name="Front desk (transfer demo)",
+        workflow_type="single_prompt",
+        first_message="Hi, thanks for calling. How can I help?",
+    ).data
+    print("created agent:", agent_id)
+
+    tools = AgentTools(api_key=api_key)
+
+    # 2a. Cold transfer — direct connect to a human or number.
+    tools.add_transfer_call(
+        agent_id,
+        number="+15551234567",
+        transfer_type="cold_transfer",
+    )
+
+    # 2b. Warm transfer — agent debriefs the destination; hold music plays to the
+    #     caller during the handover. Uncomment to use instead of the cold one above.
+    # tools.add_transfer_call(
+    #     agent_id,
+    #     number="+15551234567",
+    #     transfer_type="warm_transfer",
+    #     on_hold_music="relaxing_sound",  # ringtone | relaxing_sound | uplifting_beats | none
+    # )
+
+    # 3. Read back the live tools.
+    for tool in tools.get_tools(agent_id):
+        print("tool:", tool.type, tool.name, getattr(tool, "transfer_number", ""))
+
+    print(
+        "\nThe agent now transfers when the caller asks. Attach a phone number and "
+        "place a call to try it (see `smallestai agent-crew deploy` / the cookbook)."
+    )
+
+    # 4. Clean up the demo tool if you want:
+    # tools.remove_tool(agent_id, "transfer_call")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ markers = [
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]
-exclude = ["src/smallestai/atoms/crew", "src/smallestai/atoms/helpers", "src/smallestai/cli", "src/smallestai/waves/text_to_speech/client.py", "src/smallestai/waves/text_to_speech/raw_client.py", "src/smallestai/waves/stream_tts.py"]
+exclude = ["examples/crew_transfer_node.py", "src/smallestai/atoms/crew", "src/smallestai/atoms/helpers", "src/smallestai/cli", "src/smallestai/waves/text_to_speech/client.py", "src/smallestai/waves/text_to_speech/raw_client.py", "src/smallestai/waves/stream_tts.py"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Runnable `examples/` for the 5.4.0 transfer + crew work, matching exactly what we verified live:

- **`transfer_call.py`** — configure a `transfer_call` tool on a single-prompt agent with `AgentTools` (branch flow → takes effect on live calls). Shows **cold vs warm** and `on_hold_music` (warm only).
- **`crew_transfer_node.py`** — a crew node with a custom OpenAI-compatible LLM (Claude) that emits `SDKAgentTransferConversationEvent`. Bakes in the 5.4.0 context-seeding behavior and the cold-vs-warm music rule. Template import is guarded so the file imports cleanly.
- **`inspect_calls.py`** — list / get calls, transcript, recording; notes that a `no_answer` transfer leg fired but the destination didn't pick up.

All three parse + import cleanly against `origin/main`.