### PR TITLE
fix(crew): stop generating after a handoff (release 5.4.1)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## 5.4.1 - unreleased
+## 5.4.1 - 2026-08-04
 
 * **crew**: stop generating after a handoff. Once a node emits a transfer or
   end-call event, `OutputCrewNode` latches and ignores further LLM requests. A

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## 5.4.1 - unreleased
+
+* **crew**: stop generating after a handoff. Once a node emits a transfer or
+  end-call event, `OutputCrewNode` latches and ignores further LLM requests. A
+  fire-and-forget tool that emits the event records no tool_result, so the LLM
+  would otherwise re-decide the same action on every subsequent request and
+  re-fire it in a loop (e.g. a hold-message repeating for the whole transfer dial).
+
 ## 5.4.0 - 2026-08-04
 
 Configure agent tools (transfer_call, end_call, ...) from code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.4.0"
+version = "5.4.1"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/atoms/crew/nodes/output_crew.py
+++ b/src/smallestai/atoms/crew/nodes/output_crew.py
@@ -17,17 +17,23 @@ from loguru import logger
 from smallestai.atoms.crew.context import ContextManager
 from smallestai.atoms.crew.events import (
     OutputAgentSettings,
+    SDKAgentEndCallEvent,
     SDKAgentErrorEvent,
     SDKAgentLLMResponseChunkEvent,
     SDKAgentLLMResponseEndEvent,
     SDKAgentLLMResponseStartEvent,
     SDKAgentSpeakEvent,
     SDKAgentTranscriptUpdateEvent,
+    SDKAgentTransferConversationEvent,
     SDKEvent,
     SDKSystemInitEvent,
     SDKSystemLLMRequestEvent,
     SDKSystemUpdateOutputAgentSettingsEvent,
 )
+
+# Events that hand the call off / end it. Once one is emitted the conversation is
+# over for this node, so we stop responding to further LLM requests.
+_HANDOFF_EVENTS = (SDKAgentTransferConversationEvent, SDKAgentEndCallEvent)
 from smallestai.atoms.crew.nodes.base import CrewNode
 from smallestai.atoms.crew.task_manager import TaskManager
 
@@ -64,10 +70,23 @@ class OutputCrewNode(CrewNode):
         super().__init__(name, is_interruptible)
         self.settings = OutputAgentSettings()
         self.context = ContextManager()
+        # Latched once a handoff (transfer / end-call) event is emitted. After a
+        # handoff there is nothing to generate, and generating anyway causes a
+        # feedback loop: a tool that emits the event is fire-and-forget (no
+        # tool_result is recorded), so the LLM keeps re-deciding the same action
+        # on every subsequent request — repeatedly re-firing the event / speech.
+        self._handoff_started = False
 
     async def start(self, init_event: SDKSystemInitEvent, task_manager: TaskManager):
         """Start the node"""
         await super().start(init_event, task_manager)
+
+    async def send_event(self, event: SDKEvent):
+        """Emit an event, latching handoff state so we stop generating after a
+        transfer / end-call. Preserves base behavior otherwise."""
+        if isinstance(event, _HANDOFF_EVENTS):
+            self._handoff_started = True
+        await super().send_event(event)
 
     async def _update_settings(self, settings: Dict[str, Any]):
         """Update the settings for this node"""
@@ -80,6 +99,11 @@ class OutputCrewNode(CrewNode):
         `on_event` override, so a subclass can't accidentally silence the agent
         (e.g. by dropping the LLM-request -> generate_response path)."""
         if isinstance(event, SDKSystemLLMRequestEvent):
+            # After a handoff (transfer / end-call) there is nothing to generate;
+            # ignore further LLM requests so the node doesn't re-decide and
+            # re-fire the same terminal action in a loop.
+            if self._handoff_started:
+                return
             # The LLM-request event carries the platform's authoritative message
             # list. Sync the user/assistant conversation from it so
             # generate_response always sees the latest user turn, instead of

--- a/tests/custom/test_crew_terminal_handoff_guard.py
+++ b/tests/custom/test_crew_terminal_handoff_guard.py
@@ -10,6 +10,7 @@ import unittest
 from unittest import mock
 
 from smallestai.atoms.crew.nodes import OutputCrewNode
+from smallestai.atoms.crew.nodes.base import CrewNode
 from smallestai.atoms.crew.events import (
     SDKSystemLLMRequestEvent,
     SDKAgentTransferConversationEvent,
@@ -47,7 +48,7 @@ class TerminalHandoffGuardTest(unittest.IsolatedAsyncioTestCase):
         a = _Agent()
         a._handle_llm_request = mock.AsyncMock()
         # emit a transfer through the real send_event override (super().send_event is stubbed)
-        with mock.patch.object(OutputCrewNode.__mro__[1], "send_event", new=mock.AsyncMock()):
+        with mock.patch.object(CrewNode, "send_event", new=mock.AsyncMock()):
             await a.send_event(_transfer_event())
         self.assertTrue(a._handoff_started)
         await a.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "still there?"}]))
@@ -56,7 +57,7 @@ class TerminalHandoffGuardTest(unittest.IsolatedAsyncioTestCase):
     async def test_end_call_also_latches(self):
         a = _Agent()
         a._handle_llm_request = mock.AsyncMock()
-        with mock.patch.object(OutputCrewNode.__mro__[1], "send_event", new=mock.AsyncMock()):
+        with mock.patch.object(CrewNode, "send_event", new=mock.AsyncMock()):
             await a.send_event(SDKAgentEndCallEvent())
         self.assertTrue(a._handoff_started)
         await a.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "x"}]))
@@ -66,7 +67,7 @@ class TerminalHandoffGuardTest(unittest.IsolatedAsyncioTestCase):
         a = _Agent()
         a._handle_llm_request = mock.AsyncMock()
         from smallestai.atoms.crew.events import SDKAgentSpeakEvent
-        with mock.patch.object(OutputCrewNode.__mro__[1], "send_event", new=mock.AsyncMock()):
+        with mock.patch.object(CrewNode, "send_event", new=mock.AsyncMock()):
             await a.send_event(SDKAgentSpeakEvent(text="hello"))
         self.assertFalse(a._handoff_started)
         await a.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "x"}]))

--- a/tests/custom/test_crew_terminal_handoff_guard.py
+++ b/tests/custom/test_crew_terminal_handoff_guard.py
@@ -1,0 +1,77 @@
+"""OutputCrewNode must stop generating after a handoff (transfer / end-call).
+
+Regression: a crew @function_tool that emits a transfer/end-call event is
+fire-and-forget (no tool_result recorded), so on every subsequent LLM request the
+LLM re-decides the same action and re-fires the event / hold-message in a loop
+(observed ~40x "please hold" during a ~30s transfer dial). Once a handoff event is
+emitted, the node latches and ignores further LLM requests.
+"""
+import unittest
+from unittest import mock
+
+from smallestai.atoms.crew.nodes import OutputCrewNode
+from smallestai.atoms.crew.events import (
+    SDKSystemLLMRequestEvent,
+    SDKAgentTransferConversationEvent,
+    SDKAgentEndCallEvent,
+    TransferOption,
+    TransferOptionType,
+)
+
+
+class _Agent(OutputCrewNode):
+    def __init__(self):
+        super().__init__(name="a")
+
+    async def generate_response(self):
+        if False:
+            yield ""
+
+
+def _transfer_event():
+    return SDKAgentTransferConversationEvent(
+        transfer_call_number="+15551234567",
+        transfer_options=TransferOption(type=TransferOptionType.COLD_TRANSFER),
+    )
+
+
+class TerminalHandoffGuardTest(unittest.IsolatedAsyncioTestCase):
+    async def test_llm_requests_run_before_handoff(self):
+        a = _Agent()
+        a._handle_llm_request = mock.AsyncMock()
+        a.send_event = mock.AsyncMock()  # base send_event isn't needed here
+        await a.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "hi"}]))
+        a._handle_llm_request.assert_awaited_once()
+
+    async def test_transfer_latches_and_suppresses_further_llm_requests(self):
+        a = _Agent()
+        a._handle_llm_request = mock.AsyncMock()
+        # emit a transfer through the real send_event override (super().send_event is stubbed)
+        with mock.patch.object(OutputCrewNode.__mro__[1], "send_event", new=mock.AsyncMock()):
+            await a.send_event(_transfer_event())
+        self.assertTrue(a._handoff_started)
+        await a.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "still there?"}]))
+        a._handle_llm_request.assert_not_awaited()
+
+    async def test_end_call_also_latches(self):
+        a = _Agent()
+        a._handle_llm_request = mock.AsyncMock()
+        with mock.patch.object(OutputCrewNode.__mro__[1], "send_event", new=mock.AsyncMock()):
+            await a.send_event(SDKAgentEndCallEvent())
+        self.assertTrue(a._handoff_started)
+        await a.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "x"}]))
+        a._handle_llm_request.assert_not_awaited()
+
+    async def test_non_terminal_event_does_not_latch(self):
+        a = _Agent()
+        a._handle_llm_request = mock.AsyncMock()
+        from smallestai.atoms.crew.events import SDKAgentSpeakEvent
+        with mock.patch.object(OutputCrewNode.__mro__[1], "send_event", new=mock.AsyncMock()):
+            await a.send_event(SDKAgentSpeakEvent(text="hello"))
+        self.assertFalse(a._handoff_started)
+        await a.process_event(SDKSystemLLMRequestEvent(messages=[{"role": "user", "content": "x"}]))
+        a._handle_llm_request.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
A crew `@function_tool` that emits a **transfer** or **end-call** event is fire-and-forget — no `tool_result` is recorded. So on every subsequent LLM request the model re-decides the same terminal action and re-fires it. Observed live: **~40× "please hold"** during a ~30s transfer dial.

Root-cause analysis by Sauron (**PRO-2221**).

## This is one of two fixes (defense-in-depth)
The genuine **platform gap** — the platform keeps pumping LLM requests to the crew during the transfer dial (STT was already muted, but idle + LLM-request weren't) — is fixed platform-side in **pipecat #1036** (idle latch + LLM-request gate). That's the root-cause platform fix.

This PR is the **SDK safety net**: it also guards **end-call** (which the platform transfer-gate doesn't cover) and protects crews running an older platform.

## Fix (SDK)
`OutputCrewNode` latches `_handoff_started` when the node emits `SDKAgentTransferConversationEvent` or `SDKAgentEndCallEvent` (via a `send_event` override), and ignores further `SDKSystemLLMRequestEvent`s. Pure **local node state** — independent of the 5.4.0 context-seeding (a locally-appended tool_result would be overwritten by the platform's messages each turn) and touching **no platform code**.

## Testing
4 unit tests (latch on transfer + end-call, suppression of subsequent requests, non-terminal events don't latch). `verify.py` passes. Cut as 5.4.1.

Pairs with pipecat #1036 (PRO-2221).