### PR TITLE
docs(sdk): fix waves TTS method names in reference cheatsheet

### DIFF
--- a/docs/reference/methods.md
+++ b/docs/reference/methods.md
@@ -53,7 +53,9 @@ Branch/revision model (v2). The v1 `agent_versioning_drafts` /
 
 | Do this | Call |
 |---|---|
-| Text to speech | `waves.text_to_speech.*` |
+| Text to speech (file) | `waves.synthesize_tts(...)` / `waves.synthesize_lightning(...)` |
+| Text to speech (SSE) | `waves.synthesize_sse_tts(...)` |
+| Text to speech (stream) | `waves.tts.connect(...)` |
 | Speech to text (file) | `waves.speech_to_text.transcribe(...)` |
 | Speech to text (stream) | `waves.speech_to_text.stream(...)` |
 | Voice cloning | `waves.create_voice_clone(...)` / `list_voice_clones()` |


### PR DESCRIPTION
## What

The MkDocs reference cheatsheet (`docs/reference/methods.md`) listed `waves.text_to_speech.*` for text-to-speech. That namespace does not exist on the client — copying it verbatim would `AttributeError`.

## Fix

Replace with the actual client surface (verified against the released `smallestai==5.4.1`):

| Do this | Call |
|---|---|
| Text to speech (file) | `waves.synthesize_tts(...)` / `waves.synthesize_lightning(...)` |
| Text to speech (SSE) | `waves.synthesize_sse_tts(...)` |
| Text to speech (stream) | `waves.tts.connect(...)` |

The STT (`waves.speech_to_text.transcribe` / `.stream`) and voice-cloning (`waves.create_voice_clone` / `list_voice_clones`) rows were already correct and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)