### PR TITLE
fix(cli): pass required payment url to SmallestAIEnvironment; type-guard ws

### DIFF
--- a/src/smallestai/cli/lib/client.py
+++ b/src/smallestai/cli/lib/client.py
@@ -36,6 +36,8 @@ def make_client(auth_client: AuthClient):
 
         base = base.rstrip("/")
         ws = base.replace("https://", "wss://").replace("http://", "ws://")
-        env = SmallestAIEnvironment(atoms=f"{base}/atoms/v1", waves=base, waves_ws=ws)
+        env = SmallestAIEnvironment(
+            atoms=f"{base}/atoms/v1", waves=base, waves_ws=ws, payment=base
+        )
         return SmallestAI(api_key=key, environment=env)
     return SmallestAI(api_key=key)

--- a/src/smallestai/waves/stream_tts.py
+++ b/src/smallestai/waves/stream_tts.py
@@ -169,9 +169,11 @@ class WavesStreamingTTS:
         """Synthesize a single text string and stream back PCM audio chunks."""
         self._reset_state()
         self._connect()
+        ws = self.ws
+        assert ws is not None  # _connect() raises unless the socket opened
 
         payload = self._create_payload(text)
-        self.ws.send(json.dumps(payload))
+        ws.send(json.dumps(payload))
 
         while True:
             if not self.error_queue.empty():
@@ -187,7 +189,7 @@ class WavesStreamingTTS:
                     break
                 continue
 
-        self.ws.close()
+        ws.close()
 
     def synthesize_streaming(
         self,
@@ -198,17 +200,19 @@ class WavesStreamingTTS:
         """Synthesize a stream of text chunks. Useful when piping LLM output."""
         self._reset_state()
         self._connect()
+        ws = self.ws
+        assert ws is not None  # _connect() raises unless the socket opened
 
         def send_text():
             try:
                 for text_chunk in text_stream:
                     if text_chunk.strip():
                         payload = self._create_payload(text_chunk, continue_stream=continue_stream)
-                        self.ws.send(json.dumps(payload))
+                        ws.send(json.dumps(payload))
 
                 if auto_flush:
                     flush_payload = self._create_payload("", flush=True)
-                    self.ws.send(json.dumps(flush_payload))
+                    ws.send(json.dumps(flush_payload))
             except Exception as e:
                 self.error_queue.put(e)
 
@@ -230,17 +234,19 @@ class WavesStreamingTTS:
                     break
                 continue
 
-        self.ws.close()
+        ws.close()
 
     def send_text_chunk(self, text: str, continue_stream: bool = True, flush: bool = False):
         if not self.is_connected:
             raise Exception("WebSocket not connected")
+        assert self.ws is not None  # is_connected implies the socket is set
         payload = self._create_payload(text, continue_stream=continue_stream, flush=flush)
         self.ws.send(json.dumps(payload))
 
     def flush_buffer(self):
         if not self.is_connected:
             raise Exception("WebSocket not connected")
+        assert self.ws is not None  # is_connected implies the socket is set
         payload = self._create_payload("", flush=True)
         self.ws.send(json.dumps(payload))
 


### PR DESCRIPTION
## Two fixes in hand-maintained files (both surfaced as mypy noise; one is a real runtime bug)

### 1. `make_client` runtime bug (real)
`SmallestAIEnvironment.__init__` requires `payment` (`*, atoms, waves, waves_ws, payment`). The `SMALLEST_BASE_URL` branch in `cli/lib/client.py` built the env without it, so `make_client` raised `TypeError` at runtime whenever a user pointed the CLI at a custom endpoint (dev rig / self-host). Now passes `payment=base`.

### 2. `stream_tts.py` type-safety
`self.ws` is `Optional[WebSocketApp]`. `send()`/`close()` were called on it directly, tripping mypy `union-attr`. Capture a non-None local after `_connect()` (and `assert` after the `is_connected` guards) so the calls are type-safe. No behavior change — `_connect()` already raises unless the socket opened.

Clears the pre-existing mypy `union-attr` / `call-arg` errors in these two files. mypy-clean (`--follow-imports=silent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)