### PR TITLE
ci(docs): self-enable Pages via configure-pages to prevent deploy 404

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,12 @@ jobs:
           python-version: "3.11"
       - name: Install docs deps
         run: pip install -e . mkdocs-material "mkdocstrings[python]"
+      # Enable + configure Pages from the workflow itself so the deploy step
+      # doesn't 404 with "Ensure GitHub Pages has been enabled" if the repo's
+      # Pages state gets reset. Idempotent.
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Build
         run: mkdocs build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Problem

The `docs` workflow's deploy step intermittently failed:

```
Error: Creating Pages deployment failed
Error: HttpError: Not Found ... Ensure GitHub Pages has been enabled
```

This happens when the repo's Pages state gets reset (`status: null`), so `actions/deploy-pages` 404s creating the deployment. I re-set the Pages source to GitHub Actions via the API (site is live again, 200), but that's manual and can recur.

## Fix

Add `actions/configure-pages@v5` with `enablement: true` in the build job. The workflow now enables + configures Pages itself before uploading the artifact, so the deploy step won't 404 if the state resets. Idempotent — no-op when Pages is already enabled. Workflow permissions already include `pages: write` + `id-token: write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)