### PR TITLE
feat(cli): surface crew-vs-platform config ownership (init + doctor) [5.7.0]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+## 5.7.0 - 2026-08-07
+
+* **cli**: `smallestai agent-crew init` now prints the crew-vs-platform config ownership
+  boundary, so it's clear up front that a crew owns only the LLM turn and everything else
+  (voice, STT, PII redaction, first message, timeouts) is platform config.
+* **cli**: new `smallestai agent-crew doctor [--agent-id]` command. Inspects an agent for
+  common gotchas: no live crew build, wrong workflow type, PII redaction ON (rewrites the
+  transcript), and `transfer_call` enabled in the dashboard Tools panel (a no-op for crew
+  agents). Prints the ownership tables.
+* **crew**: `SDKSystemUpdateOutputAgentSettingsEvent` is deprecated (emits a
+  `DeprecationWarning`). The platform does not apply crew-sent output-agent settings; a
+  crew cannot override platform-owned config at runtime. It will be removed in a future
+  release.
+
 ## 5.5.0 - 2026-08-05
 
 DevX pass (backward-compatible).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.5.0"
+version = "5.7.0"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/atoms/crew/events.py
+++ b/src/smallestai/atoms/crew/events.py
@@ -225,7 +225,26 @@ class SDKSystemInitEvent(SDKSystemEvent, type=EventType.SYSTEM_INIT.value):
 class SDKSystemUpdateOutputAgentSettingsEvent(
     SDKSystemEvent, type=EventType.SYSTEM_UPDATE_OUTPUT_AGENT_SETTINGS.value
 ):
+    """Deprecated. The platform does not apply crew-sent output-agent settings.
+
+    A crew owns only the LLM turn; platform-owned settings (voice, STT, redaction,
+    interruption, ...) cannot be overridden at runtime from crew code. Emitting this
+    event has no effect and it will be removed in a future release.
+    """
+
     settings: Dict[str, Any]
+
+    def __init__(self, **data: Any) -> None:
+        import warnings
+
+        warnings.warn(
+            "SDKSystemUpdateOutputAgentSettingsEvent is deprecated and not applied by the "
+            "platform. A crew cannot override platform-owned settings (voice, STT, redaction, "
+            "interruption). This event will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**data)
 
 
 class SDKSystemUserJoinedEvent(SDKSystemEvent, type=EventType.SYSTEM_USER_JOINED.value):

--- a/src/smallestai/cli/agent_crew.py
+++ b/src/smallestai/cli/agent_crew.py
@@ -16,6 +16,8 @@ from rich.table import Table
 from smallestai.cli.lib.atoms import AgentBuildStatus, AtomsAPIClient
 from smallestai.cli.lib.auth import AuthClient
 from smallestai.cli.lib.chat import ChatClient, chat_loop
+from smallestai.cli.lib.ownership import SUMMARY as OWNERSHIP_SUMMARY
+from smallestai.cli.lib.ownership import render_ownership
 from smallestai.cli.lib.project_config import ProjectConfig
 from smallestai.cli.utils import create_zip_from_directory, find_required_env_vars
 
@@ -63,6 +65,7 @@ def initialise_agent_crew_app(
             console.print(
                 f"[green]Agent initialized successfully with ID: [bold]{agent_id_arg}[/bold][/green]"
             )
+            _print_ownership_hint()
             return
 
         # Without an id, the picker needs a real TTY — fail clearly instead of crashing.
@@ -115,6 +118,18 @@ def initialise_agent_crew_app(
 
         project_config.set_agent_id(selected_agent)
         console.print("[green]Agent initialized successfully![/green]")
+        _print_ownership_hint()
+
+    def _print_ownership_hint():
+        console.print(
+            Panel(
+                OWNERSHIP_SUMMARY
+                + "\n\n[dim]Run [bold]smallestai agent-crew doctor[/bold] to check this "
+                "agent's config for common gotchas.[/dim]",
+                title="What your crew controls vs the platform",
+                border_style="cyan",
+            )
+        )
 
     @app.command()
     def deploy(
@@ -564,5 +579,93 @@ def initialise_agent_crew_app(
     #         console.print("\n[yellow]Streaming stopped by user.[/yellow]")
     #     except Exception as e:
     #         console.print(f"[red]Error streaming build logs: {e}[/red]")
+
+    @app.command()
+    def doctor(
+        agent_id: Optional[str] = typer.Option(
+            None,
+            "--agent-id",
+            help="Agent id to inspect. Defaults to the agent linked in this project.",
+        ),
+    ):
+        """Check a crew agent's config for common gotchas (live build, redaction, dashboard tools)."""
+        asyncio.run(async_doctor(agent_id))
+
+    async def async_doctor(agent_id_arg: Optional[str]):
+        agent_id = agent_id_arg or project_config.get_agent_id()
+        if not agent_id:
+            console.print(
+                "[red]No agent id. Pass --agent-id <id>, or run `init` first.[/red]"
+            )
+            raise typer.Exit(1)
+
+        credentials = auth_client.get_credentials()
+        if not credentials or not credentials.get("access_token"):
+            console.print(
+                "[red]You must be logged in. Run 'smallestai auth login'.[/red]"
+            )
+            raise typer.Exit(1)
+        token = credentials["access_token"]
+
+        console.print(f"[dim]Inspecting agent {agent_id}...[/dim]")
+        try:
+            agent = await atoms_client.get_agent_raw(token, agent_id)
+        except Exception as e:
+            console.print(f"[red]Could not fetch agent: {e}[/red]")
+            raise typer.Exit(1)
+        try:
+            builds = await atoms_client.list_agent_builds(agent_id, token)
+            build_items = builds.builds
+        except Exception:
+            build_items = []
+
+        oks: list[str] = []
+        warns: list[str] = []
+
+        live = [b for b in build_items if b.is_live]
+        if live:
+            oks.append(f"A crew build is live ({live[0].id[:12]}...).")
+        else:
+            warns.append(
+                "No live crew build. Run `agent-crew deploy`, then make the build live, "
+                "or your crew code will not serve."
+            )
+
+        wft = agent.get("workflowType")
+        if wft and wft != "single_prompt":
+            warns.append(
+                f"workflowType is '{wft}'. A crew attaches to single_prompt agents."
+            )
+
+        if (agent.get("redactionConfig") or {}).get("isEnabled"):
+            warns.append(
+                "PII redaction is ON. It rewrites emails/names/numbers in the transcript "
+                "(and can trim leading words like 'my email address is'). Set "
+                "redactionConfig.isEnabled off if you don't want it."
+            )
+        else:
+            oks.append("PII redaction is off.")
+
+        sp = (agent.get("workflow") or {}).get("singlePromptConfig") or agent.get(
+            "singlePromptConfig"
+        ) or {}
+        tools = sp.get("tools") or []
+        tool_repr = " ".join(str(t).lower() for t in tools)
+        if "transfer" in tool_repr:
+            warns.append(
+                "The dashboard Tools panel has transfer_call enabled. For a crew agent that "
+                "panel is ignored (your code-side @function_tool is used). Leave it off to "
+                "avoid confusion."
+            )
+
+        console.print()
+        for m in oks:
+            console.print(f"[green]OK[/green]   {m}")
+        for m in warns:
+            console.print(f"[yellow]WARN[/yellow] {m}")
+        if not warns:
+            console.print("[bold green]No issues found.[/bold green]")
+        console.print()
+        render_ownership(console)
 
     return app

--- a/src/smallestai/cli/lib/atoms.py
+++ b/src/smallestai/cli/lib/atoms.py
@@ -161,6 +161,23 @@ class AtomsAPIClient:
 
             return agents_response.data
 
+    async def get_agent_raw(self, access_token: str, agent_id: str) -> dict:
+        """Fetch a single agent's full config as a raw dict (for `doctor` inspection)."""
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{self.base_url}/atoms/v1/agent/{agent_id}",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            response.raise_for_status()
+            body = response.json()
+            if isinstance(body, dict) and body.get("status") is False:
+                raise Exception(body.get("errors"))
+            data = body.get("data", body) if isinstance(body, dict) else body
+            # some responses nest under data.agent
+            if isinstance(data, dict) and "agent" in data and isinstance(data["agent"], dict):
+                data = data["agent"]
+            return data if isinstance(data, dict) else {}
+
     async def get_account_details(
         self,
         access_token: str,

--- a/src/smallestai/cli/lib/ownership.py
+++ b/src/smallestai/cli/lib/ownership.py
@@ -1,0 +1,69 @@
+"""Crew-vs-platform config ownership: the single source of truth for the CLI.
+
+A crew build takes over ONLY the LLM turn. Everything else about the call stays on
+the platform agent config and is read fresh each call. This module holds that boundary
+as data so `init` and `doctor` can surface it consistently.
+
+See AGENT_SDK_OWNERSHIP.md for the full matrix and rationale.
+"""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from rich.console import Console
+from rich.table import Table
+
+# (concern, where it is configured)
+CREW_OWNS: List[Tuple[str, str]] = [
+    ("System prompt / LLM messages", "crew code"),
+    ("Function tools (@function_tool, incl. transfer_call)", "crew code"),
+    ("end_call / speak() / mute / unmute", "crew code"),
+]
+
+# (concern, platform field)
+PLATFORM_OWNS: List[Tuple[str, str]] = [
+    ("PII redaction", "redactionConfig.isEnabled"),
+    ("Voice / TTS (provider, speed, ...)", "synthesizer*"),
+    ("STT provider + language + switching", "transcriberType, defaultLanguage"),
+    ("First message", "firstMessage"),
+    ("Interruption / VAD / smart-turn", "allowInterruptions, smartTurnConfig"),
+    ("Voicemail detection / denoising", "voiceMailDetectionConfig, denoisingConfig"),
+    ("Session / idle timeouts", "sessionTimeoutConfig, llmIdleTimeoutConfig"),
+    ("Background sound / pronunciation", "backgroundSound, pronunciationDicts"),
+]
+
+# Editing these on the dashboard for a crew agent does nothing (safe no-ops).
+DASHBOARD_NO_OPS: List[str] = [
+    "The Tools panel (including its transfer_call toggle)",
+    "The single-prompt prompt field",
+    "The model dropdown (the crew serves its own LLM)",
+]
+
+SUMMARY = (
+    "A crew build owns ONLY the LLM turn (prompt, messages, @function_tools, end_call, "
+    "speak, mute). Everything else - voice, STT, PII redaction, first message, timeouts - "
+    "is platform config: set it in the agent settings (dashboard or API), it takes effect "
+    "on the next call, no redeploy. The dashboard Tools panel and prompt field are ignored "
+    "for a crew agent."
+)
+
+
+def render_ownership(console: Console) -> None:
+    """Print the crew-vs-platform ownership tables + no-ops to the console."""
+    crew = Table(title="Your crew code owns (the LLM turn)", title_style="bold cyan", show_edge=True)
+    crew.add_column("Concern")
+    crew.add_column("Configured in")
+    for concern, where in CREW_OWNS:
+        crew.add_row(concern, where)
+
+    plat = Table(title="The platform owns (set in agent settings, no redeploy)", title_style="bold magenta")
+    plat.add_column("Concern")
+    plat.add_column("Field")
+    for concern, field in PLATFORM_OWNS:
+        plat.add_row(concern, field)
+
+    console.print(crew)
+    console.print(plat)
+    console.print("[dim]Ignored for a crew agent (safe to leave alone on the dashboard):[/dim]")
+    for item in DASHBOARD_NO_OPS:
+        console.print(f"  [dim]- {item}[/dim]")

--- a/tests/custom/test_crew_ownership_cli.py
+++ b/tests/custom/test_crew_ownership_cli.py
@@ -1,0 +1,42 @@
+"""Crew config-ownership surfacing: ownership module, deprecation, doctor command."""
+import warnings
+
+from rich.console import Console
+
+
+def test_ownership_module_has_data_and_renders():
+    from smallestai.cli.lib import ownership
+
+    assert ownership.CREW_OWNS
+    assert ownership.PLATFORM_OWNS
+    assert ownership.DASHBOARD_NO_OPS
+    assert "LLM turn" in ownership.SUMMARY
+    # any platform-owned field mentions redaction (the key gotcha)
+    assert any("redaction" in field.lower() for _, field in ownership.PLATFORM_OWNS)
+    ownership.render_ownership(Console())  # must not raise
+
+
+def test_override_event_is_deprecated():
+    from smallestai.atoms.crew.events import SDKSystemUpdateOutputAgentSettingsEvent
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        SDKSystemUpdateOutputAgentSettingsEvent(settings={})
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_agent_crew_app_exposes_doctor():
+    from smallestai.cli.agent_crew import initialise_agent_crew_app
+    from smallestai.cli.lib.atoms import AtomsAPIClient
+    from smallestai.cli.lib.auth import AuthClient
+    from smallestai.cli.lib.project_config import ProjectConfig
+
+    app = initialise_agent_crew_app(ProjectConfig(), AuthClient(), AtomsAPIClient())
+    names = {cmd.name or cmd.callback.__name__ for cmd in app.registered_commands}
+    assert "doctor" in names
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Surfaces the crew ownership boundary in the SDK/CLI, off a real customer confusion (a crew agent with `transfer_call` toggled in the dashboard + PII redaction on).

## What
- **Shared ownership matrix** (`cli/lib/ownership.py`): a crew owns only the LLM turn (prompt, messages, `@function_tool`s, end/transfer/speak/mute); the platform owns voice/STT/**PII redaction**/first-message/timeouts, read fresh per call.
- **`agent-crew init`** prints the ownership summary after linking.
- **New `agent-crew doctor [--agent-id]`** — inspects an agent and flags: no live crew build, non-`single_prompt` workflow, **PII redaction ON** (rewrites the transcript), and `transfer_call` enabled in the dashboard Tools panel (inert for crew agents).
- **Deprecates `SDKSystemUpdateOutputAgentSettingsEvent`** (emits `DeprecationWarning`) — the platform never applies crew-sent output-agent settings; removal in a future release.

## Verified
- `doctor` run **live** against a real agent: correctly flagged "PII redaction is ON" and confirmed the live build.
- `pytest tests/custom` — 101 passed, 1 skipped (no regressions); new `test_crew_ownership_cli.py` = 3 passed.
- mypy: new files clean. (Two pre-existing mypy warnings in the `builds` command are unrelated and present on `main`.)

## Notes for review
- Version set to **5.7.0** assuming the adapters PR (#90, 5.6.0) merges first; adjust if merge order differs.
- Docs counterpart: smallest-ai-documentation#363. Canonical matrix: `AGENT_SDK_OWNERSHIP.md`.
- Deferred from Sauron's Prompt 1: the `deploy` pre-flight lint (heuristic scan of user code) — left out to avoid false positives; `doctor` covers the same ground more reliably.

**Draft — merging bumps the version and auto-publishes. Hold for your review.**