### PR TITLE
feat(telemetry): anonymous opt-out usage telemetry via PostHog (5.9.0)

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -62,3 +62,6 @@ src/smallestai/waves/helpers/**
 
 # Hand-written README (do not regenerate)
 README.md
+
+# Anonymous opt-out telemetry (hand-written)
+src/smallestai/telemetry.py

--- a/README.md
+++ b/README.md
@@ -231,6 +231,20 @@ client = SmallestAI(
 - Full API reference: [reference.md](./reference.md)
 - Product docs: https://smallest.ai/docs
 
+## Telemetry
+
+The SDK sends anonymous, aggregated usage telemetry (which CLI commands run, deploy
+outcomes) so we can see what to improve. It never includes personal data or secrets:
+no API keys, agent ids, prompts, transcripts, phone numbers, file paths, or error
+messages. Only the event name, SDK / Python / OS version, and a random anonymous
+install id. It is fire-and-forget and never blocks your program.
+
+Opt out any time:
+
+```bash
+export SMALLESTAI_TELEMETRY=0    # or DO_NOT_TRACK=1
+```
+
 ## Contributing
 
 Most of `src/` is generated from an API spec and gets overwritten on regeneration,

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## 5.9.0 - 2026-08-07
+
+* **telemetry**: anonymous, opt-out usage telemetry (PostHog). Sends lightweight product
+  events (CLI command groups, and deploy/lifecycle events as they are wired in) so we can
+  see what to improve. No personal data or secrets - only the event name, SDK/Python/OS
+  version, and a random anonymous install id; geography is derived server-side. Sent
+  fire-and-forget over httpx (no new dependency), never blocks or raises. Opt out with
+  `SMALLESTAI_TELEMETRY=0` (or `DO_NOT_TRACK=1`); one-time notice on first run. See README.
+
 ## 5.5.0 - 2026-08-05
 
 DevX pass (backward-compatible).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.5.0"
+version = "5.9.0"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/cli/main.py
+++ b/src/smallestai/cli/main.py
@@ -45,6 +45,14 @@ app.add_typer(phone_numbers_app, name="phone-numbers")
 
 
 def main():
+    import sys
+
+    from smallestai import telemetry
+
+    telemetry.maybe_show_first_run_notice()
+    # Coarse command group only (e.g. "agent-crew", "auth"); never args or their values.
+    command = sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith("-") else ""
+    telemetry.capture("cli_invoked", {"command": command})
     app()
 
 

--- a/src/smallestai/telemetry.py
+++ b/src/smallestai/telemetry.py
@@ -1,0 +1,135 @@
+"""Anonymous, opt-out usage telemetry.
+
+Sends lightweight product events (CLI usage, deploy outcomes) to PostHog so we can see
+what to improve. It is deliberately minimal and privacy-first:
+
+- NO personal data or secrets: never an API key, agent id, prompt, transcript, phone
+  number, file path, or error message. Only the event name, SDK / Python / OS version,
+  and a random anonymous install id.
+- Geography (country) is derived server-side by PostHog from the request IP; no location
+  is ever collected client-side.
+- Fire-and-forget on a daemon thread. It never blocks and never raises.
+
+Opt out any time:
+
+    export SMALLESTAI_TELEMETRY=0      # or DO_NOT_TRACK=1
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# PostHog project (US cloud). The phc_ key is write-only and safe to ship in a client.
+_POSTHOG_HOST = "https://us.i.posthog.com"
+_PROJECT_KEY = "phc_vqBpz5cQHFjsmfFix6KuCjf8iwtH2hJaeReHPSq46PyH"
+
+_OFF_VALUES = {"0", "false", "no", "off"}
+_ON_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_enabled() -> bool:
+    """Telemetry is on by default; disabled by SMALLESTAI_TELEMETRY or DO_NOT_TRACK."""
+    if os.getenv("SMALLESTAI_TELEMETRY", "").strip().lower() in _OFF_VALUES:
+        return False
+    if os.getenv("DO_NOT_TRACK", "").strip().lower() in _ON_VALUES:
+        return False
+    return True
+
+
+def _config_dir() -> Path:
+    base = os.getenv("XDG_CONFIG_HOME") or os.path.join(str(Path.home()), ".config")
+    return Path(base) / "smallestai"
+
+
+def _state_file() -> Path:
+    return _config_dir() / "telemetry.json"
+
+
+def _read_state() -> Dict[str, Any]:
+    try:
+        return json.loads(_state_file().read_text())
+    except Exception:
+        return {}
+
+
+def _write_state(state: Dict[str, Any]) -> None:
+    try:
+        _config_dir().mkdir(parents=True, exist_ok=True)
+        _state_file().write_text(json.dumps(state))
+    except Exception:
+        pass
+
+
+def install_id() -> str:
+    """A random anonymous id, persisted once per install. Not tied to any account."""
+    state = _read_state()
+    iid = state.get("install_id")
+    if not iid:
+        iid = uuid.uuid4().hex
+        state["install_id"] = iid
+        _write_state(state)
+    return iid
+
+
+def _sdk_version() -> str:
+    try:
+        from smallestai.version import __version__
+
+        return __version__
+    except Exception:
+        return "unknown"
+
+
+def _base_properties() -> Dict[str, Any]:
+    return {
+        "sdk_version": _sdk_version(),
+        "python_version": platform.python_version(),
+        "os": platform.system(),
+    }
+
+
+def maybe_show_first_run_notice() -> None:
+    """Print a one-time notice about anonymous telemetry (only if enabled)."""
+    if not is_enabled():
+        return
+    state = _read_state()
+    if state.get("notice_shown"):
+        return
+    state["notice_shown"] = True
+    _write_state(state)
+    try:
+        print(
+            "smallestai collects anonymous usage telemetry to improve the SDK "
+            "(no personal data or secrets). Opt out with SMALLESTAI_TELEMETRY=0.",
+            flush=True,
+        )
+    except Exception:
+        pass
+
+
+def _post(event: str, properties: Dict[str, Any]) -> None:
+    try:
+        import httpx
+
+        payload = {
+            "api_key": _PROJECT_KEY,
+            "event": event,
+            "distinct_id": install_id(),
+            "properties": properties,
+        }
+        httpx.post(f"{_POSTHOG_HOST}/capture/", json=payload, timeout=2.0)
+    except Exception:
+        pass  # telemetry must never affect the caller
+
+
+def capture(event: str, properties: Optional[Dict[str, Any]] = None) -> None:
+    """Fire-and-forget an anonymous event. Never blocks, never raises, respects opt-out."""
+    if not is_enabled():
+        return
+    props = {**_base_properties(), **(properties or {})}
+    threading.Thread(target=_post, args=(event, props), daemon=True).start()

--- a/tests/custom/test_telemetry.py
+++ b/tests/custom/test_telemetry.py
@@ -1,0 +1,77 @@
+"""Anonymous opt-out telemetry: opt-out, anonymous id, no-PII payload, non-blocking."""
+import smallestai.telemetry as telemetry
+
+
+def test_opt_out_env_vars(monkeypatch):
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setenv("SMALLESTAI_TELEMETRY", "0")
+    assert telemetry.is_enabled() is False
+    monkeypatch.setenv("SMALLESTAI_TELEMETRY", "1")
+    assert telemetry.is_enabled() is True
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    assert telemetry.is_enabled() is False
+
+
+def test_install_id_is_anonymous_and_persists(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    first = telemetry.install_id()
+    second = telemetry.install_id()
+    assert first == second
+    assert len(first) == 32  # a uuid4 hex, not an account id
+
+
+def test_disabled_capture_sends_nothing(monkeypatch):
+    monkeypatch.setenv("SMALLESTAI_TELEMETRY", "0")
+    calls = []
+    monkeypatch.setattr(telemetry, "_post", lambda e, p: calls.append(e))
+    telemetry.capture("cli_invoked", {"command": "agent-crew"})
+    assert calls == []
+
+
+def test_enabled_capture_payload_has_versions_and_no_secrets(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("SMALLESTAI_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    captured = {}
+
+    def fake_post(event, props):
+        captured["event"] = event
+        captured["props"] = props
+
+    class _ImmediateThread:
+        def __init__(self, target, args=(), daemon=None):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    monkeypatch.setattr(telemetry, "_post", fake_post)
+    monkeypatch.setattr(telemetry.threading, "Thread", _ImmediateThread)
+
+    telemetry.capture("cli_invoked", {"command": "agent-crew"})
+
+    assert captured["event"] == "cli_invoked"
+    props = captured["props"]
+    assert {"sdk_version", "python_version", "os"} <= set(props)
+    assert props["command"] == "agent-crew"
+    # never leak identifying/secret keys
+    blob = str(props).lower()
+    for banned in ("api_key", "sk_", "token", "phone", "prompt", "transcript"):
+        assert banned not in blob
+
+
+def test_first_run_notice_shows_once(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("SMALLESTAI_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    telemetry.maybe_show_first_run_notice()
+    telemetry.maybe_show_first_run_notice()
+    out = capsys.readouterr().out
+    assert out.count("anonymous usage telemetry") == 1
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What
`smallestai.telemetry`: fire-and-forget **anonymous, opt-out** product telemetry so we can see what to improve. Sends to the existing PostHog project.

## Privacy (by design)
- **No PII or secrets.** Never an API key, agent id, prompt, transcript, phone number, file path, or error message. Only: event name, SDK/Python/OS version, a random anonymous install id (uuid4 in a local config file, not tied to any account).
- **Geography** is derived server-side by PostHog from the request IP; no location is collected client-side.
- **On by default** (industry norm), opt out with `SMALLESTAI_TELEMETRY=0` or `DO_NOT_TRACK=1`; one-time notice on first run; disclosed in the README.
- **Never blocks or raises.** Daemon thread, 2s timeout, all exceptions swallowed.

## Why PostHog over OTel / a custom endpoint
Product telemetry (installs, feature usage, funnels, geo) is PostHog's job; OTel is for distributed tracing (heavier, wrong shape). Sends over `httpx` (already a dep) to `/capture/` with the write-only `phc_` key, so **no new dependency and no backend ingest to build**.

## Wiring
- CLI entry captures a coarse `cli_invoked` event (command group only, e.g. `agent-crew`).
- Richer events (`crew_deploy` success/fail, `agent_created`, errors) are a fast follow once #90/#91 land, to avoid CLI merge conflicts.

## Checks
- `pytest tests/custom/test_telemetry.py` — 5 passed (opt-out, anonymous id, no-secret payload, once-only notice).
- `mypy src/smallestai/telemetry.py` — clean. CLI still runs.
- Live: PostHog `/capture/` accepts our event (see PR checks / smoke).

**Draft — merging bumps 5.9.0 and auto-publishes. Hold for your review.** Version assumes #90/#91/#92 merge first.