### PR TITLE
feat(cli): welcome banner + mcp command (5.10.0)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## 5.10.0 - 2026-08-07
+
+* **cli**: running bare `smallestai` now shows a banner + command list instead of a
+  "Missing command" error.
+* **cli**: new `smallestai mcp` command to set up or run the Smallest AI MCP server
+  (`@smallest-ai/mcp-server`) for Cursor / Claude and other MCP clients. `smallestai mcp`
+  prints the client config + `claude mcp add` command; `smallestai mcp run` launches it via
+  npx; `smallestai mcp config` prints the mcp.json snippet.
+
 ## 5.5.0 - 2026-08-05
 
 DevX pass (backward-compatible).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.5.0"
+version = "5.10.0"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/cli/main.py
+++ b/src/smallestai/cli/main.py
@@ -2,12 +2,14 @@
 
 import typer
 from rich.console import Console
+from rich.table import Table
 
 from smallestai.cli.agent_crew import initialise_agent_crew_app
 from smallestai.cli.agents import initialise_agents_app
 from smallestai.cli.auth import initialise_auth_app
 from smallestai.cli.calls import initialise_calls_app
 from smallestai.cli.campaigns import initialise_campaigns_app
+from smallestai.cli.mcp import initialise_mcp_app
 from smallestai.cli.phone_numbers import initialise_phone_numbers_app
 from smallestai.cli.waves import initialise_waves_app
 from smallestai.cli.lib.atoms import AtomsAPIClient
@@ -16,7 +18,50 @@ from smallestai.cli.lib.project_config import ProjectConfig
 
 console = Console()
 
-app = typer.Typer(help="SmallestAI CLI")
+app = typer.Typer(help="SmallestAI CLI", no_args_is_help=False, rich_markup_mode="rich")
+
+_BANNER = r"""[bold magenta]
+  ███████╗███╗   ███╗ █████╗ ██╗     ██╗     ███████╗███████╗████████╗
+  ██╔════╝████╗ ████║██╔══██╗██║     ██║     ██╔════╝██╔════╝╚══██╔══╝
+  ███████╗██╔████╔██║███████║██║     ██║     █████╗  ███████╗   ██║
+  ╚════██║██║╚██╔╝██║██╔══██║██║     ██║     ██╔══╝  ╚════██║   ██║
+  ███████║██║ ╚═╝ ██║██║  ██║███████╗███████╗███████╗███████║   ██║
+  ╚══════╝╚═╝     ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚══════╝   ╚═╝[/bold magenta]"""
+
+_COMMANDS = [
+    ("agent-crew", "Init, deploy, and manage crew (custom-LLM) voice agents"),
+    ("agents", "Create, inspect, and call voice agents"),
+    ("calls", "Inspect call logs, transcripts, and recordings"),
+    ("campaigns", "Manage outbound calling campaigns"),
+    ("phone-numbers", "Search, rent, and manage phone numbers"),
+    ("waves", "Text-to-speech, speech-to-text, and voices"),
+    ("mcp", "Set up the Smallest AI MCP server for Cursor / Claude"),
+    ("auth", "Log in and manage credentials"),
+]
+
+
+def _print_welcome() -> None:
+    console.print(_BANNER)
+    console.print("  [dim]Build, deploy, and run voice agents and speech models.[/dim]\n")
+    table = Table(show_header=False, box=None, padding=(0, 2, 0, 2))
+    table.add_column(style="bold cyan", no_wrap=True)
+    table.add_column(style="white")
+    for name, desc in _COMMANDS:
+        table.add_row(name, desc)
+    console.print(table)
+    console.print(
+        "\n  [dim]Run [bold]smallestai <command> --help[/bold] for details, "
+        "or [bold]smallestai --help[/bold] for everything.[/dim]\n"
+    )
+
+
+@app.callback(invoke_without_command=True)
+def _root(ctx: typer.Context) -> None:
+    """SmallestAI CLI."""
+    if ctx.invoked_subcommand is None:
+        _print_welcome()
+        raise typer.Exit()
+
 
 auth_client = AuthClient()
 atoms_client = AtomsAPIClient()
@@ -42,6 +87,8 @@ app.add_typer(campaigns_app, name="campaigns")
 
 phone_numbers_app = initialise_phone_numbers_app(auth_client)
 app.add_typer(phone_numbers_app, name="phone-numbers")
+
+app.add_typer(initialise_mcp_app(), name="mcp")
 
 
 def main():

--- a/src/smallestai/cli/mcp.py
+++ b/src/smallestai/cli/mcp.py
@@ -1,0 +1,83 @@
+"""`smallestai mcp` - set up or run the Smallest AI MCP server.
+
+The MCP server (github.com/smallest-inc/mcp-server, npm ``@smallest-ai/mcp-server``) gives
+Cursor, Claude, and other MCP clients native access to Waves + Atoms. It runs on Node via
+npx; this command prints the client config and can launch it for you.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+
+import typer
+from rich.console import Console
+from rich.syntax import Syntax
+
+console = Console()
+
+_NPM_PKG = "@smallest-ai/mcp-server"
+
+
+def _config_snippet() -> str:
+    return json.dumps(
+        {
+            "mcpServers": {
+                "smallest-ai": {
+                    "command": "npx",
+                    "args": ["-y", _NPM_PKG],
+                    "env": {"SMALLEST_API_KEY": "your-api-key-here"},
+                }
+            }
+        },
+        indent=2,
+    )
+
+
+def initialise_mcp_app() -> typer.Typer:
+    app = typer.Typer(
+        name="mcp",
+        help="Set up or run the Smallest AI MCP server (for Cursor, Claude, etc.).",
+        no_args_is_help=False,
+    )
+
+    @app.callback(invoke_without_command=True)
+    def _root(ctx: typer.Context) -> None:
+        if ctx.invoked_subcommand is not None:
+            return
+        console.print(
+            "[bold]Smallest AI MCP server[/bold] gives Cursor, Claude, and other MCP "
+            "clients native access to Waves + Atoms.\n"
+        )
+        console.print("[dim]Requires Node.js 18+ and a SMALLEST_API_KEY.[/dim]\n")
+        console.print("Claude Code:")
+        console.print(f"  [cyan]claude mcp add smallest-ai -- npx -y {_NPM_PKG}[/cyan]\n")
+        console.print("Cursor / Claude Desktop - add to your mcp.json:")
+        console.print(Syntax(_config_snippet(), "json", theme="ansi_dark"))
+        console.print("\n  [dim]Or run it directly: [bold]smallestai mcp run[/bold][/dim]")
+
+    @app.command("run")
+    def run() -> None:
+        """Run the MCP server locally via npx (Node.js 18+ required)."""
+        if not shutil.which("npx"):
+            console.print(
+                "[red]npx not found. Install Node.js 18+ from https://nodejs.org.[/red]"
+            )
+            raise typer.Exit(1)
+        if not os.getenv("SMALLEST_API_KEY"):
+            console.print(
+                "[yellow]SMALLEST_API_KEY is not set; the MCP server needs it.[/yellow]"
+            )
+        console.print(f"[dim]Launching {_NPM_PKG} via npx (Ctrl-C to stop)...[/dim]")
+        try:
+            subprocess.run(["npx", "-y", _NPM_PKG], check=False)
+        except KeyboardInterrupt:
+            pass
+
+    @app.command("config")
+    def config() -> None:
+        """Print the mcp.json config snippet."""
+        console.print(Syntax(_config_snippet(), "json", theme="ansi_dark"))
+
+    return app

--- a/tests/custom/test_cli_banner_mcp.py
+++ b/tests/custom/test_cli_banner_mcp.py
@@ -1,0 +1,33 @@
+"""Bare `smallestai` shows a banner (not an error), and `mcp` prints setup config."""
+from typer.testing import CliRunner
+
+from smallestai.cli.main import app
+
+runner = CliRunner()
+
+
+def test_bare_cli_shows_banner_and_commands_not_error():
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "Missing command" not in result.output
+    # command list is present
+    for name in ("agent-crew", "agents", "calls", "waves", "mcp"):
+        assert name in result.output
+
+
+def test_mcp_prints_setup_config():
+    result = runner.invoke(app, ["mcp"])
+    assert result.exit_code == 0
+    assert "@smallest-ai/mcp-server" in result.output
+
+
+def test_mcp_config_subcommand_emits_json():
+    result = runner.invoke(app, ["mcp", "config"])
+    assert result.exit_code == 0
+    assert "mcpServers" in result.output
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Two DevX polish items.

## 1. Bare `smallestai` shows a banner, not an error
Previously `smallestai` with no command errored with "Missing command". Now it prints an ASCII banner + a tidy command list (via an `invoke_without_command` callback), exit 0. `--help` and subcommands are unchanged.

```
  ███████╗███╗   ███╗ █████╗ ██╗     ██╗     ███████╗███████╗████████╗
  ...
  agent-crew       Init, deploy, and manage crew (custom-LLM) voice agents
  agents           Create, inspect, and call voice agents
  mcp              Set up the Smallest AI MCP server for Cursor / Claude
  ...
```

## 2. `smallestai mcp`
Helper for the (Node) MCP server `@smallest-ai/mcp-server`:
- `smallestai mcp` — prints the client config + `claude mcp add smallest-ai -- npx -y @smallest-ai/mcp-server`.
- `smallestai mcp run` — launches it via npx (Node 18+; warns if `SMALLEST_API_KEY` unset).
- `smallestai mcp config` — prints the `mcp.json` snippet.

## Checks
- `pytest tests/custom/test_cli_banner_mcp.py` — 3 passed (bare = banner not error; mcp config present).
- `mypy` clean; `--help` + subcommands verified.

Note: touches `cli/main.py`, which the telemetry PR (#93) also edits — trivial merge. Version 5.10.0 assumes the other CLI/feature PRs merge first.

**Draft — merging bumps version + auto-publishes. Hold for your review.**