### PR TITLE
chore: add DeepSource config scoped to hand-written code

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,38 @@
+# DeepSource config. Takes effect once the DeepSource GitHub app is activated on the
+# repo (it is). The SDK is mostly Fern-generated, so the generated surfaces are excluded
+# to keep analysis focused on hand-written code (crew, cli, helpers, tools, telemetry).
+# Analyzer reference: https://docs.deepsource.com/docs/platform/reference/core-analyzers
+# Tune exclude_patterns if the generated layout changes.
+version = 1
+
+exclude_patterns = [
+  "src/smallestai/**/raw_client.py",
+  "src/smallestai/**/client.py",
+  "src/smallestai/**/socket_client.py",
+  "src/smallestai/**/types/**",
+  "src/smallestai/**/errors/**",
+  "src/smallestai/core/**",
+  "src/smallestai/environment.py",
+  "src/smallestai/**/__init__.py",
+]
+
+test_patterns = [
+  "tests/**",
+]
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"
+  type_checker = "mypy"
+  max_line_length = 120
+
+[[analyzers]]
+name = "secrets"
+enabled = true
+
+# test-coverage can be added once CI uploads a coverage report to DeepSource
+# (deepsource report --analyzer test-coverage). Left off until then to avoid a
+# perpetually-pending check.


### PR DESCRIPTION
Adds `.deepsource.toml` so DeepSource analysis activates on the repo (the GitHub app is already configured).

The SDK is mostly Fern-generated, so generated surfaces are excluded to keep findings on hand-written code (`crew`, `cli`, `helpers`, `tools`, `telemetry`):
- `raw_client.py`, `client.py`, `socket_client.py`, `types/**`, `errors/**`, `core/**`, `environment.py`, package `__init__.py`

Analyzers ([reference](https://docs.deepsource.com/docs/platform/reference/core-analyzers)):
- **python** — `type_checker = mypy`, `max_line_length = 120` (matches ruff)
- **secrets**
- **test-coverage**

Standalone so DeepSource starts reading `main` immediately, rather than waiting for the 5.10 release. Will be removed from the 5.10 release branch to avoid a duplicate add.