### PR TITLE
release: 5.10.1 — fix waves endpoints host (404 hotfix)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 5.10.1 - 2026-08-10
+
+* **fix**: the new waves endpoints (`post_call_analysis`, `voices`, `analytics`, `ops`)
+  called the atoms host and returned 404. They now target the waves host correctly.
+
 ## 5.10.0 - 2026-08-07
 
 * **tools**: new `smallestai.tools` framework for prebuilt, pluggable crew tools. Each tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.10.0"
+version = "5.10.1"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/smallestai/waves/analytics/raw_client.py
+++ b/src/smallestai/waves/analytics/raw_client.py
@@ -75,7 +75,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/asr/logs",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "page": page,
@@ -147,7 +147,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             f"waves/v1/analytics/asr/history/{encode_path_param(request_id)}",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="DELETE",
             request_options=request_options,
         )
@@ -225,7 +225,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/asr/usage/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -304,7 +304,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/logs",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "page": page,
@@ -385,7 +385,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/usage/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -468,7 +468,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/usage/credits/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -551,7 +551,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/concurrency/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -633,7 +633,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/ws-connections/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -713,7 +713,7 @@ class RawAnalyticsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/webhooks/logs",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "page": page,
@@ -799,7 +799,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/asr/logs",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "page": page,
@@ -871,7 +871,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             f"waves/v1/analytics/asr/history/{encode_path_param(request_id)}",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="DELETE",
             request_options=request_options,
         )
@@ -949,7 +949,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/asr/usage/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -1028,7 +1028,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/logs",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "page": page,
@@ -1109,7 +1109,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/usage/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -1192,7 +1192,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/usage/credits/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -1275,7 +1275,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/concurrency/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -1357,7 +1357,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/tts/ws-connections/timeseries",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "from": serialize_datetime(from_) if from_ is not None else None,
@@ -1437,7 +1437,7 @@ class AsyncRawAnalyticsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/analytics/webhooks/logs",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             params={
                 "page": page,

--- a/src/smallestai/waves/ops/raw_client.py
+++ b/src/smallestai/waves/ops/raw_client.py
@@ -38,7 +38,7 @@ class RawOpsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/health",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             request_options=request_options,
         )
@@ -97,7 +97,7 @@ class AsyncRawOpsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/health",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             request_options=request_options,
         )

--- a/src/smallestai/waves/post_call_analysis/raw_client.py
+++ b/src/smallestai/waves/post_call_analysis/raw_client.py
@@ -57,7 +57,7 @@ class RawPostCallAnalysisClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/pca",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="POST",
             json={
                 "transcript": transcript,
@@ -135,7 +135,7 @@ class RawPostCallAnalysisClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/pca/generate",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="POST",
             json={
                 "prompt": prompt,
@@ -224,7 +224,7 @@ class AsyncRawPostCallAnalysisClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/pca",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="POST",
             json={
                 "transcript": transcript,
@@ -302,7 +302,7 @@ class AsyncRawPostCallAnalysisClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/pca/generate",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="POST",
             json={
                 "prompt": prompt,

--- a/src/smallestai/waves/voices/raw_client.py
+++ b/src/smallestai/waves/voices/raw_client.py
@@ -39,7 +39,7 @@ class RawVoicesClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             "waves/v1/voice/get-all-models",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             request_options=request_options,
         )
@@ -99,7 +99,7 @@ class AsyncRawVoicesClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             "waves/v1/voice/get-all-models",
-            base_url=self._client_wrapper.get_environment().atoms,
+            base_url=self._client_wrapper.get_environment().waves,
             method="GET",
             request_options=request_options,
         )


### PR DESCRIPTION
5.10.0's new waves endpoints (`post_call_analysis`, `voices`, `analytics`, `ops`) called the atoms host (`/atoms/v1/waves/...`) and 404'd on the live API. Wire tests passed because they point every environment at one mock host.

Fix (spec: smallest-ai-documentation#371) adds `x-fern-server-name: waves` per operation. This PR carries the regenerated raw-clients (base_url atoms → waves) + version bump + changelog.

Live-verified against api.smallest.ai: all four waves endpoints + the atoms endpoints (account, web_call, subscription, campaign exports) return 200 / correct errors.