### PR TITLE
release: 5.11.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+## 5.11.0 - 2026-08-19
+
+* **cli**: refreshed the bare `smallestai` banner - a "SMALLEST AI" wordmark in the brand
+  blue `#3B82F6` with pulsing concentric rings on an interactive terminal (static when piped,
+  in CI, or under `NO_COLOR` / `SMALLESTAI_NO_ANIM`; compact on narrow terminals).
+* **cli**: renamed the speech command group from `waves` to `models` (text-to-speech,
+  speech-to-text, voices). `waves` still works as a hidden, back-compatible alias.
+* **fix (crew)**: startup validation no longer logs a spurious `Startup validation failed -
+  pod will not accept sessions. ValueError: Session not initialized` on every healthy boot.
+  The dry-run now builds the graph and halts cleanly; genuinely broken handlers (bad node
+  `__init__`, imports, cycles) still fail validation and keep the pod not-ready.
+
 ## 5.10.1 - 2026-08-10
 
 * **fix**: the new waves endpoints (`post_call_analysis`, `voices`, `analytics`, `ops`)

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@
   in CI, or under `NO_COLOR` / `SMALLESTAI_NO_ANIM`; compact on narrow terminals).
 * **cli**: renamed the speech command group from `waves` to `models` (text-to-speech,
   speech-to-text, voices). `waves` still works as a hidden, back-compatible alias.
+* **cli**: new `smallestai calls events <call-id>` streams a live call's events (transcript,
+  per-turn latency, node transitions, tool calls, errors); `calls transcript --follow` streams
+  just the conversation; `agent-crew logs [build-id]` streams a build's compile + deploy logs.
 * **fix (crew)**: startup validation no longer logs a spurious `Startup validation failed -
   pod will not accept sessions. ValueError: Session not initialized` on every healthy boot.
   The dry-run now builds the graph and halts cleanly; genuinely broken handlers (bad node

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.10.1"
+version = "5.11.0"
 description = ""
 readme = "README.md"
 authors = []


### PR DESCRIPTION
Version bump + changelog for **5.11.0**, bundling the CLI work on main:

- **#98** — CLI banner refresh (SMALLEST AI, `#3B82F6`, pulsing rings) + `waves`→`models` group rename (hidden `waves` alias).
- **#99** — crew startup validation no longer logs the false-positive `Session not initialized` error on healthy boots.
- **#100** — `calls events` / `calls transcript --follow` / `agent-crew logs` (live call events + build logs).

**Merge #100 before this**, then merge this, then dispatch the **release** workflow with version `5.11.0` (it requires the changelog entry this PR adds) to publish to PyPI.

Follow-up once 5.11.0 is on PyPI: merge docs #375 to delete the crew boot-log notes.