### PR TITLE
release: 5.11.1 — crew tool-call events

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## 5.11.1 - 2026-08-20
+
+* **fix (crew)**: crew tool calls now show on the platform's Events tab. The crew
+  `ToolRegistry` emits `tool_call_start`/`tool_call_end`/`tool_call_error` events over
+  the node websocket around each `@function_tool` (including `transfer_call`), in the same
+  format single-prompt agents already produce. Previously crew tools ran silently, so a
+  crew `transfer_call` was invisible on the platform even though it fired. No change to
+  user crew code; takes effect on redeploy.
+
 ## 5.11.0 - 2026-08-19
 
 * **cli**: refreshed the bare `smallestai` banner - a "SMALLEST AI" wordmark in the brand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "smallestai"
-version = "5.11.0"
+version = "5.11.1"
 description = ""
 readme = "README.md"
 authors = []


### PR DESCRIPTION
Version bump + changelog for **5.11.1**: crew tool calls (incl. `transfer_call`) now emit `tool_call_*` events to the platform (#102). After merge, dispatch the release workflow with `5.11.1`.