### PR TITLE
feat(helpers): Tools + Secrets managers for the reusable-tools registry

### DIFF
--- a/src/smallestai/atoms/helpers/__init__.py
+++ b/src/smallestai/atoms/helpers/__init__.py
@@ -6,6 +6,8 @@ from smallestai.atoms.helpers.audience import Audience
 from smallestai.atoms.helpers.call import Call, CallAnalytics
 from smallestai.atoms.helpers.campaign import Campaign
 from smallestai.atoms.helpers.kb import KB
+from smallestai.atoms.helpers.secrets import Secrets
+from smallestai.atoms.helpers.tools import Tools
 from smallestai.atoms.helpers.versioning import (
     BaseRevisionUnavailableError,
     DraftConflictError,
@@ -29,6 +31,8 @@ __all__ = [
     "Call",
     "Campaign",
     "KB",
+    "Secrets",
+    "Tools",
     "Page",
     "as_page",
     "require_id",

--- a/src/smallestai/atoms/helpers/secrets.py
+++ b/src/smallestai/atoms/helpers/secrets.py
@@ -1,0 +1,76 @@
+"""
+Secrets vault.
+
+The org-level, write-only Secrets vault: store API keys and tokens encrypted and
+reference them by name from a tool's ``auth`` block. Values are never returned —
+``list`` and ``create`` surface the name only.
+
+Usage:
+    from smallestai.atoms.helpers import Secrets
+
+    secrets = Secrets()
+    secrets.create(name="ORDER_API_TOKEN", value="sk_live_...")
+    secrets.list()          # names only
+    secrets.delete(secret_id)
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+DEFAULT_BASE_URL = "https://api.smallest.ai/atoms/v1"
+
+
+class Secrets:
+    """Manager for the org Secrets vault (``/secret``).
+
+    Standalone:
+        secrets = Secrets()
+        secrets.list()
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        """
+        Args:
+            base_url: API base URL (default: api.smallest.ai/atoms/v1)
+            api_key: API key (default: SMALLEST_API_KEY env var)
+        """
+        self.base_url = base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)
+        self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def list(self) -> Dict[str, Any]:
+        """List the org's secret names (values are never returned)."""
+        url = f"{self.base_url}/secret"
+        response = requests.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def create(self, name: str, value: str) -> Dict[str, Any]:
+        """Create a secret. The value is encrypted at rest; the response holds the name only.
+
+        Args:
+            name: secret name (letters, numbers, underscores) — referenced from a tool's ``auth``.
+            value: the secret value (write-only).
+        """
+        url = f"{self.base_url}/secret"
+        response = requests.post(url, headers=self._get_headers(), json={"name": name, "value": value})
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def delete(self, secret_id: str) -> Dict[str, Any]:
+        """Delete a secret by its id."""
+        url = f"{self.base_url}/secret/{secret_id}"
+        response = requests.delete(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]

--- a/src/smallestai/atoms/helpers/tools.py
+++ b/src/smallestai/atoms/helpers/tools.py
@@ -1,0 +1,103 @@
+"""
+Reusable Tools library.
+
+The org-level Tools registry: create a tool once and reference it from any number
+of agents by its ``toolId``. Two types are registry tools — ``api_call`` and
+``client_tool``. System tools (transfer, end-call, knowledge-base search) are
+configured per-agent, not here.
+
+Usage:
+    from smallestai.atoms.helpers import Tools
+
+    tools = Tools()
+    created = tools.create({
+        "type": "api_call",
+        "name": "get_order_status",
+        "description": "Look up an order by id.",
+        "method": "GET",
+        "url": "https://api.example.com/orders/{{order_id}}",
+        "llmParameters": [
+            {"name": "order_id", "type": "text", "description": "The order id", "required": True}
+        ],
+    })
+    tool_id = created["data"]["toolId"]
+    tools.list()
+    tools.update(tool_id, {...})
+    tools.duplicate(tool_id)
+    tools.delete(tool_id)
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+DEFAULT_BASE_URL = "https://api.smallest.ai/atoms/v1"
+
+
+class Tools:
+    """Manager for the org Tools library (``/tool``).
+
+    Standalone:
+        tools = Tools()
+        tools.list()
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        """
+        Args:
+            base_url: API base URL (default: api.smallest.ai/atoms/v1)
+            api_key: API key (default: SMALLEST_API_KEY env var)
+        """
+        self.base_url = base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)
+        self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def list(self) -> Dict[str, Any]:
+        """List the org's tools."""
+        url = f"{self.base_url}/tool"
+        response = requests.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def create(self, definition: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a tool.
+
+        Args:
+            definition: the tool body (``type`` ``api_call`` or ``client_tool``,
+                plus ``name``, ``description``, and the fields for that type).
+        """
+        url = f"{self.base_url}/tool"
+        response = requests.post(url, headers=self._get_headers(), json={"definition": definition})
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def update(self, tool_id: str, definition: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a tool. Propagates to every agent that references it."""
+        url = f"{self.base_url}/tool/{tool_id}"
+        response = requests.patch(url, headers=self._get_headers(), json={"definition": definition})
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def duplicate(self, tool_id: str) -> Dict[str, Any]:
+        """Duplicate a tool into a new library tool with a new ``toolId``."""
+        url = f"{self.base_url}/tool/{tool_id}/duplicate"
+        response = requests.post(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    def delete(self, tool_id: str) -> Dict[str, Any]:
+        """Delete a tool. Blocked (400) while any agent still references it."""
+        url = f"{self.base_url}/tool/{tool_id}"
+        response = requests.delete(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]


### PR DESCRIPTION
## What
Hand-written helper managers for the reusable Tools library and Secrets vault, matching the existing `smallestai.atoms.helpers` pattern (standalone `requests` wrappers, base_url + api_key, `.fernignore`-preserved).

```python
from smallestai.atoms.helpers import Tools, Secrets

tools = Tools()
created = tools.create({"type": "api_call", "name": "get_order_status", ...})
tools.list(); tools.update(tool_id, {...}); tools.duplicate(tool_id); tools.delete(tool_id)

secrets = Secrets()
secrets.create(name="ORDER_API_TOKEN", value="sk_live_...")   # write-only
secrets.list(); secrets.delete(secret_id)
```

- **Tools** (`/tool`): list, create, update, delete, duplicate.
- **Secrets** (`/secret`): list (names only), create, delete.

## Verified
- Compiles; imports; exported from `smallestai.atoms.helpers`.
- **Live read-only smoke test** against the API: `Tools().list()` and `Secrets().list()` both return `status: true` with the correct `{status, data}` envelope.

## Notes
- Standalone HTTP wrappers, so they work against the live endpoints today (no dependency on regenerating the SDK from the api-ref PR).
- Pairs with docs #409 (api-ref for `/tool` + `/secret`) and #408 (platform docs).