### PR TITLE
fix(waves): serialize STT query params passed through the escape hatch

### DIFF
--- a/src/smallestai/waves/helpers/streaming_stt.py
+++ b/src/smallestai/waves/helpers/streaming_stt.py
@@ -32,38 +32,27 @@ underlying ``stream()`` returns (a sync or async context manager).
 
 Booleans are sent to the server as the strings ``"true"`` / ``"false"``, and list
 params (``keywords``, ``redact_pii``, ``redact_pci``) are sent comma-joined, matching
-what the endpoint expects.
+what the endpoint expects. Params given through ``additional_query_parameters`` or
+``request_options["additional_query_parameters"]`` are shaped the same way, so an
+unnamed knob reaches the wire in the form the endpoint reads.
 """
 
 import typing
 
 __all__ = ["stream_speech_to_text", "build_stt_stream_query"]
 
-# Sent to the server as "true" / "false" (the controller compares === "true").
-_BOOLEAN_KNOBS = frozenset(
-    {
-        "word_timestamps",
-        "sentence_timestamps",
-        "diarize",
-        "punctuate",
-        "capitalize",
-        "itn_normalize",
-        "numerals",
-        "finalize_on_words",
-        "full_transcript",
-        "vad",
-        "vad_events",
-    }
-)
 
-# Sent comma-joined when given a list/tuple (a plain string passes through as-is).
-_LIST_KNOBS = frozenset({"keywords", "redact_pii", "redact_pci"})
+def _coerce(value: typing.Any) -> typing.Any:
+    """Put one query value in the shape the handshake expects.
 
-
-def _coerce(key: str, value: typing.Any) -> typing.Any:
-    if key in _BOOLEAN_KNOBS and isinstance(value, bool):
+    Booleans go as "true" / "false" (the controller compares === "true") and
+    list/tuple values go comma-joined; a plain string passes through as-is. Keyed off
+    the value's type rather than the param name so params the SDK does not know yet,
+    which are exactly what the escape hatch is for, serialize the same way.
+    """
+    if isinstance(value, bool):
         return "true" if value else "false"
-    if key in _LIST_KNOBS and isinstance(value, (list, tuple)):
+    if isinstance(value, (list, tuple)):
         return ",".join(str(v) for v in value)
     return value
 
@@ -137,9 +126,9 @@ def build_stt_stream_query(
     for key, value in optional.items():
         if value is None:
             continue
-        params[key] = _coerce(key, value)
-    if additional_query_parameters:
-        params.update(additional_query_parameters)
+        params[key] = _coerce(value)
+    for key, value in (additional_query_parameters or {}).items():
+        params[key] = _coerce(value)
     return params
 
 
@@ -209,6 +198,8 @@ def stream_speech_to_text(
         additional_query_parameters=additional_query_parameters,
     )
     resolved: typing.Dict[str, typing.Any] = dict(request_options or {})
-    caller_overrides = resolved.get("additional_query_parameters") or {}
+    caller_overrides = {
+        key: _coerce(value) for key, value in (resolved.get("additional_query_parameters") or {}).items()
+    }
     resolved["additional_query_parameters"] = {**query, **caller_overrides}
     return client.waves.speech_to_text.stream(request_options=resolved)

--- a/tests/custom/test_streaming_stt_helper.py
+++ b/tests/custom/test_streaming_stt_helper.py
@@ -139,6 +139,38 @@ def test_existing_request_options_preserved():
     assert ro["additional_query_parameters"]["language"] == "en"
 
 
+def test_additional_query_parameters_are_serialized_like_typed_ones():
+    """The escape hatch used to hand the value straight to the query string, so a bool
+    reached the wire as "True" (the controller compares === "true") and a list as its
+    Python repr, silently turning the knob off."""
+    q = build_stt_stream_query(
+        language="en",
+        additional_query_parameters={"punctuate": True, "diarize": False, "keywords": ["a", "b"]},
+    )
+    assert q["punctuate"] == "true"
+    assert q["diarize"] == "false"
+    assert q["keywords"] == "a,b"
+
+
+def test_a_knob_the_sdk_does_not_name_is_serialized_too():
+    """Unnamed params are exactly what the escape hatch is for, so they get the same shape."""
+    q = build_stt_stream_query(language="en", additional_query_parameters={"some_new_flag": True})
+    assert q["some_new_flag"] == "true"
+
+
+def test_request_options_query_overrides_are_serialized():
+    """The second way a caller passes raw query params bypassed the same coercion."""
+    client = _FakeClient()
+    stream_speech_to_text(
+        client,
+        language="en",
+        request_options={"additional_query_parameters": {"vad": True, "keywords": ["x", "y"]}},
+    )
+    aqp = client._stt.captured_request_options["additional_query_parameters"]
+    assert aqp["vad"] == "true"
+    assert aqp["keywords"] == "x,y"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
`build_stt_stream_query` normalises the handshake params it names: booleans go out as `"true"` / `"false"` because the controller compares `=== "true"`, and `keywords` / `redact_pii` / `redact_pci` go out comma-joined. Anything passed through `additional_query_parameters` skipped that and went onto the query string as-is.

So the two paths disagree on the same knob:

```python
>>> from smallestai.waves.helpers.streaming_stt import build_stt_stream_query as b
>>> import urllib.parse
>>> typed = b(language="en", punctuate=True, keywords=["a", "b"])
>>> urllib.parse.urlencode({k: v for k, v in typed.items() if k in ("punctuate", "keywords")})
'punctuate=true&keywords=a%2Cb'

>>> esc = b(language="en", additional_query_parameters={"punctuate": True, "keywords": ["a", "b"]})
>>> urllib.parse.urlencode({k: v for k, v in esc.items() if k in ("punctuate", "keywords")})
'punctuate=True&keywords=%5B%27a%27%2C+%27b%27%5D'
```

`punctuate=True` is not `"true"`, so punctuation stays off. `keywords` arrives as a Python list repr, so keyword boosting matches nothing. Neither one errors, the socket opens, the session runs, the knob is just quietly ignored.

`request_options["additional_query_parameters"]` bypasses the same coercion in `stream_speech_to_text`, so both documented ways of passing raw params are affected.

## The change

`_coerce` now keys off the value's type rather than the param name, and runs over the escape-hatch params too.

The two frozensets listed exactly the bool-typed and list-typed params in the signature, so switching to a type check is equivalent for every named param, and it also covers the params the SDK does not name yet, which is what the escape hatch is for. A knob the server adds tomorrow now serialises correctly without an SDK release. Net effect is less code.

The alternative was to keep the name lists and look up escape-hatch keys in them. That fixes the two knobs above but still sends a raw `True` for anything newer than the SDK, which felt like leaving the bug half-fixed.

## Tests

Three added to `tests/custom/test_streaming_stt_helper.py`, covering both bypass paths and an unnamed knob. All three fail on `main` and pass here. The existing 12 in that file are unchanged and still pass, which is what pins the equivalence for named params.

Both files are `.fernignore`d, so a regen keeps them.

I did not have an API key to run this against the live Pulse endpoint, so the wire-format claim rests on the `=== "true"` comparison your own module docstring documents. Happy to redo it against a real session if you want that.
