### PR TITLE
fix(waves): close the TTS socket on every path out of a stream

### DIFF
--- a/src/smallestai/waves/stream_tts.py
+++ b/src/smallestai/waves/stream_tts.py
@@ -63,6 +63,11 @@ class WavesStreamingTTS:
         config = TTSConfig(voice_id="magnus", api_key="...")
         streaming_tts = WavesStreamingTTS(config)
         audio_chunks = list(streaming_tts.synthesize("Hello world"))
+
+    Each generator closes its own socket when it finishes, raises, or is abandoned
+    part way through. ``start_streaming_session`` drives the socket by hand through
+    ``send_text_chunk`` / ``flush_buffer``, so call ``close()`` when that session is
+    over if you never exhaust the generator.
     """
 
     # Unified TTS streaming endpoint. The old per-model URL
@@ -138,8 +143,7 @@ class WavesStreamingTTS:
             self.audio_queue.put(None)
 
     def _connect(self):
-        if self.ws:
-            self.ws.close()
+        self.close()
 
         self.ws = WebSocketApp(
             self.ws_url,
@@ -161,11 +165,19 @@ class WavesStreamingTTS:
             time.sleep(0.1)
 
         if not self.is_connected:
+            self.close()
             raise Exception(
                 "Failed to connect to WebSocket "
                 f"{self.ws_url} within {timeout}s. "
                 "Check your network and that SMALLEST_API_KEY is valid."
             )
+
+    def close(self):
+        """Close the socket if one is open. Safe to call more than once."""
+        ws, self.ws = self.ws, None
+        self.is_connected = False
+        if ws is not None:
+            ws.close()
 
     def synthesize(self, text: str) -> Generator[bytes, None, None]:
         """Synthesize a single text string and stream back PCM audio chunks."""
@@ -177,21 +189,22 @@ class WavesStreamingTTS:
         payload = self._create_payload(text)
         ws.send(json.dumps(payload))
 
-        while True:
-            if not self.error_queue.empty():
-                raise self.error_queue.get()
+        try:
+            while True:
+                if not self.error_queue.empty():
+                    raise self.error_queue.get()
 
-            try:
-                chunk = self.audio_queue.get(timeout=1.0)
-                if chunk is None:
-                    break
-                yield chunk
-            except queue.Empty:
-                if self.is_complete:
-                    break
-                continue
-
-        ws.close()
+                try:
+                    chunk = self.audio_queue.get(timeout=1.0)
+                    if chunk is None:
+                        break
+                    yield chunk
+                except queue.Empty:
+                    if self.is_complete:
+                        break
+                    continue
+        finally:
+            self.close()
 
     def synthesize_streaming(
         self,
@@ -222,21 +235,22 @@ class WavesStreamingTTS:
         sender_thread.daemon = True
         sender_thread.start()
 
-        while True:
-            if not self.error_queue.empty():
-                raise self.error_queue.get()
+        try:
+            while True:
+                if not self.error_queue.empty():
+                    raise self.error_queue.get()
 
-            try:
-                chunk = self.audio_queue.get(timeout=1.0)
-                if chunk is None:
-                    break
-                yield chunk
-            except queue.Empty:
-                if self.is_complete:
-                    break
-                continue
-
-        ws.close()
+                try:
+                    chunk = self.audio_queue.get(timeout=1.0)
+                    if chunk is None:
+                        break
+                    yield chunk
+                except queue.Empty:
+                    if self.is_complete:
+                        break
+                    continue
+        finally:
+            self.close()
 
     def send_text_chunk(self, text: str, continue_stream: bool = True, flush: bool = False):
         if not self.is_connected:
@@ -256,19 +270,22 @@ class WavesStreamingTTS:
         self._reset_state()
         self._connect()
 
-        while True:
-            if not self.error_queue.empty():
-                raise self.error_queue.get()
+        try:
+            while True:
+                if not self.error_queue.empty():
+                    raise self.error_queue.get()
 
-            try:
-                chunk = self.audio_queue.get(timeout=0.1)
-                if chunk is None:
-                    break
-                yield chunk
-            except queue.Empty:
-                if self.is_complete:
-                    break
-                continue
+                try:
+                    chunk = self.audio_queue.get(timeout=0.1)
+                    if chunk is None:
+                        break
+                    yield chunk
+                except queue.Empty:
+                    if self.is_complete:
+                        break
+                    continue
+        finally:
+            self.close()
 
     def _reset_state(self):
         self.audio_queue = queue.Queue()

--- a/tests/custom/test_waves_stream_tts_lifecycle.py
+++ b/tests/custom/test_waves_stream_tts_lifecycle.py
@@ -1,0 +1,153 @@
+"""Socket lifecycle for the WavesStreamingTTS shim.
+
+Every path that opens the WebSocket has to close it again. Before the fix only the
+two happy paths did: an error mid-stream raised straight past the close, a caller who
+stopped consuming the generator early left it open, and start_streaming_session never
+closed at all and exposed no way to do it by hand.
+
+No network: WebSocketApp is replaced with a fake that records sends and closes and
+drives the callbacks itself.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from smallestai.waves.stream_tts import TTSConfig, WavesStreamingTTS
+
+
+class _FakeWebSocketApp:
+    """Stands in for websocket.WebSocketApp. `script` runs once the socket is open."""
+
+    script = None
+    opened = []
+
+    def __init__(self, url, header=None, on_open=None, on_message=None, on_error=None, on_close=None):
+        type(self).opened.append(self)
+        self.url = url
+        self.header = header
+        self.on_open = on_open
+        self.on_message = on_message
+        self.on_error = on_error
+        self.on_close = on_close
+        self.sent = []
+        self.close_calls = 0
+
+    def run_forever(self):
+        self.on_open(self)
+        if type(self).script is not None:
+            type(self).script(self)
+
+    def send(self, payload):
+        self.sent.append(payload)
+
+    def close(self):
+        self.close_calls += 1
+
+    # helpers the scripts use to act like the server
+    def audio(self, raw_b64, status=""):
+        self.on_message(self, json.dumps({"status": status, "data": {"audio": raw_b64}}))
+
+    def complete(self):
+        self.on_message(self, json.dumps({"status": "complete"}))
+
+    def fail(self, message):
+        self.on_message(self, json.dumps({"status": "error", "message": message}))
+
+
+def _tts(script=None):
+    _FakeWebSocketApp.script = script
+    return WavesStreamingTTS(TTSConfig(voice_id="magnus", api_key="k"))
+
+
+def _only_socket():
+    """The one socket the run opened, so a test can ask whether it was closed."""
+    assert len(_FakeWebSocketApp.opened) == 1
+    return _FakeWebSocketApp.opened[0]
+
+
+@pytest.fixture(autouse=True)
+def _fake_socket():
+    _FakeWebSocketApp.script = None
+    _FakeWebSocketApp.opened = []
+    with patch("smallestai.waves.stream_tts.WebSocketApp", _FakeWebSocketApp):
+        yield
+    _FakeWebSocketApp.script = None
+    _FakeWebSocketApp.opened = []
+
+
+def test_synthesize_closes_the_socket_when_the_stream_completes():
+    tts = _tts(lambda ws: (ws.audio("aGk="), ws.complete()))
+
+    chunks = list(tts.synthesize("hello"))
+
+    assert chunks == [b"hi"]
+    assert _only_socket().close_calls == 1
+
+
+def test_synthesize_closes_the_socket_when_the_stream_errors():
+    """The raise used to jump straight past the close, leaking the socket and its thread."""
+    tts = _tts(lambda ws: ws.fail("upstream exploded"))
+
+    with pytest.raises(Exception, match="upstream exploded"):
+        list(tts.synthesize("hello"))
+
+    assert _only_socket().close_calls == 1
+
+
+def test_synthesize_closes_the_socket_when_the_caller_stops_early():
+    """A consumer that breaks out of the loop never reached the close either."""
+    tts = _tts(lambda ws: (ws.audio("YQ=="), ws.audio("Yg=="), ws.audio("Yw==")))
+
+    stream = tts.synthesize("hello")
+    assert next(stream) == b"a"
+    stream.close()
+
+    assert _only_socket().close_calls == 1
+
+
+def test_start_streaming_session_closes_the_socket():
+    """This one had no close on any path, and no public way to reach the socket."""
+    tts = _tts(lambda ws: ws.complete())
+
+    list(tts.start_streaming_session())
+
+    assert _only_socket().close_calls == 1
+
+
+def test_close_is_public_and_safe_to_repeat():
+    tts = _tts(lambda ws: None)
+    tts._connect()
+    socket = tts.ws
+    assert socket is not None
+
+    tts.close()
+    tts.close()
+
+    assert tts.ws is None
+    assert tts.is_connected is False
+    assert socket.close_calls == 1
+
+
+def test_a_connect_that_times_out_closes_the_half_open_socket():
+    class _FastClock:
+        def __init__(self):
+            self.now = 0.0
+
+        def time(self):
+            self.now += 5.0
+            return self.now
+
+        def sleep(self, _seconds):
+            pass
+
+    never_opens = type("_NeverOpens", (_FakeWebSocketApp,), {"run_forever": lambda self: None})
+
+    with patch("smallestai.waves.stream_tts.WebSocketApp", never_opens):
+        with patch("smallestai.waves.stream_tts.time", _FastClock()):
+            tts = WavesStreamingTTS(TTSConfig(voice_id="magnus", api_key="k"))
+            with pytest.raises(Exception, match="Failed to connect"):
+                tts._connect()
+
+    assert _only_socket().close_calls == 1


### PR DESCRIPTION
`synthesize` and `synthesize_streaming` call `ws.close()` on the line after the consume loop, so the socket is closed only when that loop runs to completion. Two ordinary paths skip it:

```python
while True:
    if not self.error_queue.empty():
        raise self.error_queue.get()   # jumps straight past the close below
    ...
ws.close()
```

An error mid-stream raises out of the generator and the close never runs. A caller who stops reading early, which is just `break` in a `for` loop over the chunks, never runs it either, because abandoning a generator throws `GeneratorExit` at the `yield`. Both leak the socket and the `run_forever` thread behind it, and in a long-lived process those accumulate.

`start_streaming_session` has no `ws.close()` on any path, and the class exposes no public way to reach the socket, so a caller of that method has no supported way to release it at all. That method is the one meant for manual `send_text_chunk` / `flush_buffer` driving, which is exactly the case where the session outlives a single call.

A connect that times out also leaves its half-open `WebSocketApp` and thread behind before raising.

## The change

All three generators close in a `finally`, which covers normal completion, the raise, and the abandoned-generator case in one place. `close()` becomes public and idempotent, so the manual-session caller has something to call, and `_connect` uses it both to replace an existing socket and to clean up after a timeout.

`close()` clears `self.ws` before closing so a second call is a no-op rather than a double close on a socket that may already be gone.

## Tests

`tests/custom/test_waves_stream_tts_lifecycle.py`, six cases, no network: `WebSocketApp` is replaced with a fake that records sends and closes and drives the callbacks itself.

Five of the six fail on `main`, one for each leak described above. The sixth is the normal-completion path, which was never broken; it is there so the `finally` cannot regress it into a double close, and it asserts exactly one close.

The tests assert the socket was closed rather than that `self.ws` is `None`, so they pin the behaviour and not this particular implementation of it.

`src/smallestai/waves/stream_tts.py` is `.fernignore`d, so a regen keeps this.

## One thing left alone

`_on_close` puts the sentinel on the queue when the socket closes without `is_complete`, so a clean server-side close part way through a stream reads to the consumer as a normal end rather than a truncation. That is a behaviour change rather than a leak, so I left it out of this one. Happy to open it separately if you want it.
