### PR TITLE
fix(helpers): keep a pagination zero in as_page

### DIFF
--- a/src/smallestai/atoms/helpers/_envelope.py
+++ b/src/smallestai/atoms/helpers/_envelope.py
@@ -46,6 +46,15 @@ class Page:
     has_more: Optional[bool] = None
 
 
+def _first_present(*values: Any) -> Any:
+    """First value the server actually sent, treating 0 and False as sent.
+
+    `a or b` would skip a real 0, so a page the server honestly reports as empty
+    came back with total_count None instead of 0.
+    """
+    return next((value for value in values if value is not None), None)
+
+
 def _get(obj: Any, name: str) -> Any:
     """Attribute- or key-based access (works for pydantic models and dicts)."""
     if obj is None:
@@ -83,18 +92,16 @@ def as_page(response: Any) -> Page:
         if items is not None:
             return Page(
                 items=list(items),
-                total_count=(
-                    _get(data, "total_count")
-                    or _get(data, "total")
-                    or _get(data, "count")
-                    or _get(data, "total_campaign_count")
-                    or _get(pagination, "total")
-                    or _get(pagination, "total_count")
+                total_count=_first_present(
+                    _get(data, "total_count"),
+                    _get(data, "total"),
+                    _get(data, "count"),
+                    _get(data, "total_campaign_count"),
+                    _get(pagination, "total"),
+                    _get(pagination, "total_count"),
                 ),
-                total_pages=_get(data, "total_pages") or _get(pagination, "total_pages"),
-                has_more=(
-                    _get(data, "has_more") if _get(data, "has_more") is not None else _get(pagination, "has_more")
-                ),
+                total_pages=_first_present(_get(data, "total_pages"), _get(pagination, "total_pages")),
+                has_more=_first_present(_get(data, "has_more"), _get(pagination, "has_more")),
             )
 
     # Unknown shape — return the payload as a single-item page rather than guessing.

--- a/tests/custom/test_as_page_envelope.py
+++ b/tests/custom/test_as_page_envelope.py
@@ -49,3 +49,26 @@ def test_campaigns_total_campaign_count() -> None:
 def test_nested_pagination() -> None:
     pg = as_page(_Resp({"logs": [1, 2], "pagination": {"total": 9, "hasMore": True}}))
     assert pg.items == [1, 2] and pg.total_count == 9
+
+
+def test_an_honestly_empty_page_keeps_its_zeros() -> None:
+    # `a or b` chaining skipped a real 0, so a page the server reported as empty came
+    # back as total_count None, which reads as "the server did not say".
+    pg = as_page(_Resp({"agents": [], "total_count": 0, "total_pages": 0, "has_more": False}))
+    assert pg.items == []
+    assert pg.total_count == 0
+    assert pg.total_pages == 0
+    assert pg.has_more is False
+
+
+def test_zeros_from_nested_pagination_are_kept_too() -> None:
+    pg = as_page(_Resp({"agents": [], "pagination": {"total": 0, "total_pages": 0, "has_more": False}}))
+    assert pg.total_count == 0
+    assert pg.total_pages == 0
+    assert pg.has_more is False
+
+
+def test_a_flat_zero_still_wins_over_a_nested_value() -> None:
+    # Precedence is unchanged: the flat field is read first whether or not it is truthy.
+    pg = as_page(_Resp({"agents": [], "total_count": 0, "pagination": {"total": 7}}))
+    assert pg.total_count == 0


### PR DESCRIPTION
`as_page` picks the pagination fields out of whichever key the endpoint used, and the candidates are chained with `or`:

```python
total_count=(
    _get(data, "total_count")
    or _get(data, "total")
    ...
),
total_pages=_get(data, "total_pages") or _get(pagination, "total_pages"),
```

`or` skips a falsy value, and `0` is a perfectly real answer here. A page the server honestly reports as empty loses its zeros:

```python
>>> from smallestai.atoms.helpers._envelope import as_page
>>> as_page({"data": {"agents": [], "total_count": 0, "total_pages": 0, "has_more": False}})
Page(items=[], total_count=None, total_pages=None, has_more=False)
```

`total_count=None` means "the server did not tell us", so a caller that pages until it has seen `total_count` items, or that renders "0 of N", cannot tell an empty result from a missing field.

It is also inconsistent depending on where the zero sits in the chain, because the last term of an `or` is returned whether or not it is truthy:

```python
>>> as_page({"data": {"agents": [], "pagination": {"total": 0, "total_pages": 0, "has_more": False}}})
Page(items=[], total_count=None, total_pages=0, has_more=False)
```

Same payload, same kind of zero, one survives and one does not.

`has_more` is already correct, and it is the line directly underneath:

```python
has_more=(
    _get(data, "has_more") if _get(data, "has_more") is not None else _get(pagination, "has_more")
),
```

That explicit `is not None` is there because `False` would hit the same trap. The numeric fields just never got the same treatment.

## The change

A small `_first_present` helper that returns the first candidate which is not None, used for all three fields. Precedence is unchanged, so a flat field still wins over the nested `pagination` object whether or not it happens to be truthy. `has_more` moves onto the helper too, which is the same behaviour it had, just no longer spelled out inline.

## Tests

Three added to `tests/custom/test_as_page_envelope.py`: the flat zeros, the nested zeros, and one pinning that a flat `0` still beats a nested `7` so the fix cannot quietly reorder precedence. All three fail on `main`. The existing seven are untouched and still pass.

`_envelope.py` is `.fernignore`d, so a regen keeps this.
