### PR TITLE
fix(helpers): give the Atoms REST helpers a request timeout

### DIFF
--- a/src/smallestai/atoms/helpers/audience.py
+++ b/src/smallestai/atoms/helpers/audience.py
@@ -16,6 +16,7 @@ import requests
 
 # Default API base URL
 DEFAULT_BASE_URL = "https://api.smallest.ai/atoms/v1"
+DEFAULT_REQUEST_TIMEOUT = 30.0
 
 
 class Audience:
@@ -31,6 +32,8 @@ class Audience:
         self,
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
+        *,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
     ):
         """
         Initialize Audience manager.
@@ -38,9 +41,11 @@ class Audience:
         Args:
             base_url: API base URL (default: api.smallest.ai/atoms/v1)
             api_key: API key (default: SMALLEST_API_KEY env var)
+            request_timeout: Per-request timeout in seconds
         """
         self.base_url = base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)
         self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
+        self.request_timeout = request_timeout
 
     def _get_headers(self) -> Dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -90,7 +95,7 @@ class Audience:
             "description": description,
         }
 
-        response = requests.post(url, headers=self._get_headers(), files=files, data=data)
+        response = requests.post(url, headers=self._get_headers(), files=files, data=data, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -99,7 +104,7 @@ class Audience:
         url = f"{self.base_url}/audience/{audience_id}"
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -118,7 +123,7 @@ class Audience:
 
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
-        response = requests.get(url, headers=headers, params=params)
+        response = requests.get(url, headers=headers, params=params, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -127,7 +132,7 @@ class Audience:
         url = f"{self.base_url}/audience"
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -136,7 +141,7 @@ class Audience:
         url = f"{self.base_url}/audience/{audience_id}"
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
-        response = requests.delete(url, headers=headers)
+        response = requests.delete(url, headers=headers, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -167,6 +172,6 @@ class Audience:
                 member["lastName"] = str(i + 1)
             members.append(member)
 
-        response = requests.post(url, headers=headers, json={"members": members})
+        response = requests.post(url, headers=headers, json={"members": members}, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]

--- a/src/smallestai/atoms/helpers/call.py
+++ b/src/smallestai/atoms/helpers/call.py
@@ -16,6 +16,7 @@ import requests
 
 # Default API base URL
 DEFAULT_BASE_URL = "https://api.smallest.ai/atoms/v1"
+DEFAULT_REQUEST_TIMEOUT = 30.0
 
 
 class CallAnalytics:
@@ -34,6 +35,8 @@ class CallAnalytics:
         self,
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
+        *,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
     ):
         """
         Initialize Call manager.
@@ -41,9 +44,11 @@ class CallAnalytics:
         Args:
             base_url: API base URL (default: api.smallest.ai/atoms/v1)
             api_key: API key (default: SMALLEST_API_KEY env var)
+            request_timeout: Per-request timeout in seconds
         """
         self.base_url = base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)
         self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
+        self.request_timeout = request_timeout
 
     def _get_headers(self) -> Dict[str, str]:
         return {
@@ -58,7 +63,7 @@ class CallAnalytics:
     def get_call(self, call_id: str) -> Dict[str, Any]:
         """Get details for a single call."""
         url = f"{self.base_url}/conversation/{call_id}"
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -86,7 +91,7 @@ class CallAnalytics:
         if search:
             params["search"] = search
 
-        response = requests.get(url, headers=self._get_headers(), params=params)
+        response = requests.get(url, headers=self._get_headers(), params=params, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -97,6 +102,7 @@ class CallAnalytics:
             url,
             headers=self._get_headers(),
             json={"callIds": call_ids},
+            timeout=self.request_timeout,
         )
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
@@ -108,7 +114,7 @@ class CallAnalytics:
     def get_post_call_config(self, agent_id: str) -> Dict[str, Any]:
         """Get post-call analytics config for an agent."""
         url = f"{self.base_url}/agent/{agent_id}/post-call-analytics"
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -126,7 +132,7 @@ class CallAnalytics:
         if disposition_metrics is not None:
             payload["dispositionMetrics"] = disposition_metrics
 
-        response = requests.post(url, headers=self._get_headers(), json=payload)
+        response = requests.post(url, headers=self._get_headers(), json=payload, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 

--- a/src/smallestai/atoms/helpers/campaign.py
+++ b/src/smallestai/atoms/helpers/campaign.py
@@ -16,6 +16,7 @@ import requests
 
 # Default API base URL
 DEFAULT_BASE_URL = "https://api.smallest.ai/atoms/v1"
+DEFAULT_REQUEST_TIMEOUT = 30.0
 
 
 class Campaign:
@@ -31,6 +32,8 @@ class Campaign:
         self,
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
+        *,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
     ):
         """
         Initialize Campaign manager.
@@ -38,9 +41,11 @@ class Campaign:
         Args:
             base_url: API base URL (default: api.smallest.ai/atoms/v1)
             api_key: API key (default: SMALLEST_API_KEY env var)
+            request_timeout: Per-request timeout in seconds
         """
         self.base_url = base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)
         self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
+        self.request_timeout = request_timeout
 
     def _get_headers(self) -> Dict[str, str]:
         return {
@@ -73,14 +78,14 @@ class Campaign:
             "maxRetries": max_retries,
             "retryDelay": retry_delay,
         }
-        response = requests.post(url, headers=self._get_headers(), json=payload)  # type: ignore[arg-type]
+        response = requests.post(url, headers=self._get_headers(), json=payload, timeout=self.request_timeout)  # type: ignore[arg-type]
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def get(self, campaign_id: str) -> Dict[str, Any]:
         """Get campaign details."""
         url = f"{self.base_url}/campaign/{campaign_id}"
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -88,14 +93,14 @@ class Campaign:
         """List all campaigns."""
         url = f"{self.base_url}/campaign"
         params = {"limit": limit}
-        response = requests.get(url, headers=self._get_headers(), params=params)
+        response = requests.get(url, headers=self._get_headers(), params=params, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def delete(self, campaign_id: str) -> Dict[str, Any]:
         """Delete a campaign."""
         url = f"{self.base_url}/campaign/{campaign_id}"
-        response = requests.delete(url, headers=self._get_headers())
+        response = requests.delete(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -106,20 +111,20 @@ class Campaign:
     def start(self, campaign_id: str) -> Dict[str, Any]:
         """Start a campaign."""
         url = f"{self.base_url}/campaign/{campaign_id}/start"
-        response = requests.post(url, headers=self._get_headers())
+        response = requests.post(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def stop(self, campaign_id: str) -> Dict[str, Any]:
         """Stop a campaign."""
         url = f"{self.base_url}/campaign/{campaign_id}/stop"
-        response = requests.post(url, headers=self._get_headers())
+        response = requests.post(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def pause(self, campaign_id: str) -> Dict[str, Any]:
         """Pause a campaign."""
         url = f"{self.base_url}/campaign/{campaign_id}/pause"
-        response = requests.post(url, headers=self._get_headers())
+        response = requests.post(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]

--- a/src/smallestai/atoms/helpers/kb.py
+++ b/src/smallestai/atoms/helpers/kb.py
@@ -16,6 +16,7 @@ import requests
 
 # Default API base URL
 DEFAULT_BASE_URL = "https://api.smallest.ai/atoms/v1"
+DEFAULT_REQUEST_TIMEOUT = 30.0
 
 
 class KB:
@@ -31,6 +32,8 @@ class KB:
         self,
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
+        *,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
     ):
         """
         Initialize KB manager.
@@ -38,9 +41,11 @@ class KB:
         Args:
             base_url: API base URL (default: api.smallest.ai/atoms/v1)
             api_key: API key (default: SMALLEST_API_KEY env var)
+            request_timeout: Per-request timeout in seconds
         """
         self.base_url = base_url or os.environ.get("SMALLEST_BASE_URL", DEFAULT_BASE_URL)
         self.api_key = api_key or os.environ.get("SMALLEST_API_KEY", "")
+        self.request_timeout = request_timeout
 
     def _get_headers(self) -> Dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"}
@@ -81,7 +86,7 @@ class KB:
         if description:
             payload["description"] = description
 
-        response = requests.post(url, headers=headers, json=payload)
+        response = requests.post(url, headers=headers, json=payload, timeout=self.request_timeout)
         response.raise_for_status()
         kb_data = response.json()
 
@@ -109,35 +114,35 @@ class KB:
     def get(self, kb_id: str) -> Dict[str, Any]:
         """Get knowledge base details."""
         url = f"{self.base_url}/knowledgebase/{kb_id}"
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def list(self) -> Dict[str, Any]:
         """List all knowledge bases."""
         url = f"{self.base_url}/knowledgebase"
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def delete(self, kb_id: str) -> Dict[str, Any]:
         """Delete a knowledge base."""
         url = f"{self.base_url}/knowledgebase/{kb_id}"
-        response = requests.delete(url, headers=self._get_headers())
+        response = requests.delete(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def get_items(self, kb_id: str) -> Dict[str, Any]:
         """Get all items in a knowledge base."""
         url = f"{self.base_url}/knowledgebase/{kb_id}/items"
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def delete_item(self, kb_id: str, item_id: str) -> Dict[str, Any]:
         """Delete an item from a knowledge base."""
         url = f"{self.base_url}/knowledgebase/{kb_id}/items/{item_id}"
-        response = requests.delete(url, headers=self._get_headers())
+        response = requests.delete(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -163,7 +168,7 @@ class KB:
 
         with open(file_path, "rb") as f:
             files = {"media": (os.path.basename(file_path), f, "application/pdf")}
-            response = requests.post(url, headers=self._get_headers(), files=files)
+            response = requests.post(url, headers=self._get_headers(), files=files, timeout=self.request_timeout)
 
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
@@ -183,14 +188,14 @@ class KB:
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
 
-        response = requests.post(url, headers=headers, json={"urls": urls})
+        response = requests.post(url, headers=headers, json={"urls": urls}, timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
     def get_scraped_urls(self, kb_id: str) -> Dict[str, Any]:
         """Get all scraped URLs for a knowledge base."""
         url = f"{self.base_url}/knowledgebase/{kb_id}/scraped-urls"
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), timeout=self.request_timeout)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 
@@ -212,7 +217,7 @@ class KB:
         headers = self._get_headers()
         headers["Content-Type"] = "application/json"
 
-        response = requests.post(url, headers=headers, json={"text": text})
+        response = requests.post(url, headers=headers, json={"text": text}, timeout=self.request_timeout)
         if response.status_code == 404:
             print("Warning: Text upload API not available. Use dashboard instead.")
             return {"status": False, "error": "Text upload not available via API"}

--- a/tests/custom/test_helpers_request_timeout.py
+++ b/tests/custom/test_helpers_request_timeout.py
@@ -1,0 +1,108 @@
+"""Every helper HTTP call has to carry a timeout.
+
+`requests` has no default timeout, so a call that got none waits forever on a
+half-open connection. AgentTools already threaded a `request_timeout` through every
+call; Audience, CallAnalytics, Campaign and KB did not, so 28 call sites could hang.
+
+Logic-only: `requests` is replaced with a recorder, so nothing leaves the process.
+"""
+
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+from smallestai.atoms.helpers import audience as audience_module
+from smallestai.atoms.helpers import call as call_module
+from smallestai.atoms.helpers import campaign as campaign_module
+from smallestai.atoms.helpers import kb as kb_module
+from smallestai.atoms.helpers.agent_tools import AgentTools
+from smallestai.atoms.helpers.audience import Audience
+from smallestai.atoms.helpers.call import CallAnalytics
+from smallestai.atoms.helpers.campaign import Campaign
+from smallestai.atoms.helpers.kb import KB
+
+MANAGERS = [
+    pytest.param(Audience, audience_module, id="Audience"),
+    pytest.param(CallAnalytics, call_module, id="CallAnalytics"),
+    pytest.param(Campaign, campaign_module, id="Campaign"),
+    pytest.param(KB, kb_module, id="KB"),
+]
+
+
+class _Recorder:
+    """Stands in for the `requests` module and keeps every call's kwargs."""
+
+    def __init__(self):
+        self.calls = []
+
+    def _verb(self, name):
+        def go(*args, **kwargs):
+            self.calls.append((name, kwargs))
+            return _Response()
+
+        return go
+
+    def __getattr__(self, name):
+        if name in ("get", "post", "put", "patch", "delete"):
+            return self._verb(name)
+        raise AttributeError(name)
+
+
+class _Response:
+    status_code = 200
+    text = "{}"
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {}
+
+
+def _public_methods(manager):
+    return [
+        (name, member) for name, member in inspect.getmembers(manager, inspect.isfunction) if not name.startswith("_")
+    ]
+
+
+def _sample_args(signature):
+    """A placeholder for each required argument, so the method reaches its request."""
+    return ["x" for name, p in list(signature.parameters.items())[1:] if p.default is inspect.Parameter.empty]
+
+
+@pytest.mark.parametrize("manager, module", MANAGERS)
+def test_every_request_carries_a_timeout(manager, module):
+    recorder = _Recorder()
+    instance = manager(api_key="k")
+
+    with patch.object(module, "requests", recorder):
+        for name, method in _public_methods(manager):
+            try:
+                method(instance, *_sample_args(inspect.signature(method)))
+            except Exception:  # a method may reject the placeholder; the call is what matters
+                pass
+
+    assert recorder.calls, f"{manager.__name__} made no request to inspect"
+    missing = [name for name, kwargs in recorder.calls if kwargs.get("timeout") is None]
+    assert missing == [], f"{manager.__name__} sent no timeout on: {missing}"
+
+
+@pytest.mark.parametrize("manager, module", MANAGERS)
+def test_the_caller_can_choose_the_timeout(manager, module):
+    recorder = _Recorder()
+    instance = manager(api_key="k", request_timeout=1.5)
+
+    with patch.object(module, "requests", recorder):
+        for name, method in _public_methods(manager):
+            try:
+                method(instance, *_sample_args(inspect.signature(method)))
+            except Exception:
+                pass
+
+    assert {kwargs["timeout"] for _, kwargs in recorder.calls} == {1.5}
+
+
+@pytest.mark.parametrize("manager, module", MANAGERS)
+def test_the_default_matches_the_helper_that_already_had_one(manager, module):
+    assert module.DEFAULT_REQUEST_TIMEOUT == inspect.signature(AgentTools).parameters["request_timeout"].default


### PR DESCRIPTION
`requests` applies no timeout unless you pass one, so a call without `timeout=` blocks until the OS gives up on the socket, which on a half-open connection can be many minutes. The Atoms REST helpers make 31 calls and 28 of them had none:

```python
# call.py
response = requests.get(url, headers=self._get_headers())

# kb.py
response = requests.post(url, headers=self._get_headers(), json=payload)
```

`AgentTools`, the fifth helper in the same package, already gets this right. It takes a keyword-only `request_timeout: float = 30.0`, stores it, and passes it to every call:

```python
def _get(self, path: str) -> Any:
    resp = requests.get(f"{self.base_url}/{path}", headers=self._headers(), timeout=self.request_timeout)
```

So this is `Audience`, `CallAnalytics`, `Campaign` and `KB` catching up with the one helper beside them that already does it.

It matters most where these helpers are actually used. A voice agent reading call analytics or a knowledge base inside a request path has no way to bound the wait today, and the generated client next to it enforces 60s by default, so the hand-written helpers are the one place where a hang can happen.

## The change

The same keyword-only `request_timeout` param, the same `30.0` default, stored on the instance and passed to all 28 call sites. Nothing else moves: no new module, no shared constant to import, no change to any existing argument, and the param is keyword-only so no positional call breaks.

`versioning.py` and `_envelope.py` make no HTTP calls, so they are untouched.

## Tests

`tests/custom/test_helpers_request_timeout.py` walks every public method on each of the four managers with `requests` replaced by a recorder, then asserts that no recorded call went out without a timeout. Driving it by reflection rather than naming 28 methods means a helper method added later is covered the day it lands.

Twelve cases: every call carries a timeout, a caller-supplied value reaches all of them, and the default equals the one `AgentTools` already uses so the two cannot drift. All twelve fail on `main`.

`src/smallestai/atoms/helpers/**` is `.fernignore`d, so a regen keeps this.

Worth saying: `30.0` matches `AgentTools`, not the generated client's `60`. I took the sibling helper as the closer precedent, but happy to move all five to 60 if you would rather they match the client.
