### PR TITLE
fix(crew): key the task registry by task, not by name

### DIFF
--- a/src/smallestai/atoms/crew/session.py
+++ b/src/smallestai/atoms/crew/session.py
@@ -368,7 +368,7 @@ class CrewSession:
 
         current_tasks = self.task_manager.current_tasks()
         if current_tasks:
-            task_names = ", ".join(list(self.task_manager._tasks.keys()))
+            task_names = ", ".join(task.get_name() for task in current_tasks)
             logger.info(f"[{self.name}] Tasks: {task_names}")
             logger.info(f"[{self.name}] Waiting for {len(current_tasks)} tasks to complete")
             await asyncio.gather(*current_tasks, return_exceptions=True)

--- a/src/smallestai/atoms/crew/task_manager.py
+++ b/src/smallestai/atoms/crew/task_manager.py
@@ -107,7 +107,10 @@ class TaskManager(BaseTaskManager):
 
     def __init__(self) -> None:
         """Initialize the task manager with empty task registry."""
-        self._tasks: Dict[str, TaskData] = {}
+        # Keyed by the task itself: names are not unique, so keying by name let a
+        # second task with the same name evict the first and then, on that first
+        # task's completion, delete the live one's entry.
+        self._tasks: Dict[asyncio.Task, TaskData] = {}
         self._params: Optional[TaskManagerParams] = None
 
     def setup(self, params: TaskManagerParams):
@@ -212,8 +215,7 @@ class TaskManager(BaseTaskManager):
         Args:
             task_data: The task metadata.
         """
-        name = task_data.task.get_name()
-        self._tasks[name] = task_data
+        self._tasks[task_data.task] = task_data
 
     def _task_done_handler(self, task: asyncio.Task):
         """Handle task completion by removing the task from the registry.
@@ -222,9 +224,9 @@ class TaskManager(BaseTaskManager):
             task: The completed asyncio task.
         """
         name = task.get_name()
-        if name in self._tasks:
+        if task in self._tasks:
             try:
                 logger.debug(f"[{name}] Task done handler called")
-                del self._tasks[name]
+                del self._tasks[task]
             except KeyError as e:
                 logger.trace(f"{name}: unable to remove task data (already removed?): {e}")

--- a/tests/custom/test_crew_task_registry.py
+++ b/tests/custom/test_crew_task_registry.py
@@ -1,0 +1,95 @@
+"""Regression test: the task registry is keyed by task, not by name.
+
+Task names are not unique. CrewSession builds a handler task's name from the session,
+the event and the handler function, so the same event firing twice while the first
+handler is still running produces two live tasks with identical names. Keyed by name,
+the second evicted the first from the registry, and then the first task's done handler
+deleted the *second* entry, leaving a running task that current_tasks() never reported.
+"""
+
+import asyncio
+import unittest
+
+from smallestai.atoms.crew.task_manager import TaskManager, TaskManagerParams
+
+# The shape CrewSession._dispatch builds: f"{session}::{event}::{handler}::handler"
+COLLIDING_NAME = "sess::on_message::handle::handler"
+
+
+class TaskRegistryTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.manager = TaskManager()
+        self.manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+        self.started = []
+
+    async def _blocks(self):
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            raise
+
+    async def _finishes(self, done: asyncio.Event):
+        await asyncio.sleep(0.01)
+        done.set()
+
+    async def _drain(self):
+        for task in list(self.manager.current_tasks()):
+            await self.manager.cancel_task(task)
+
+    async def test_two_tasks_sharing_a_name_are_both_registered(self):
+        first = self.manager.create_task(self._blocks(), name=COLLIDING_NAME)
+        second = self.manager.create_task(self._blocks(), name=COLLIDING_NAME)
+
+        registered = self.manager.current_tasks()
+
+        self.assertIn(first, registered)
+        self.assertIn(second, registered)
+        self.assertEqual(len(registered), 2)
+        await self._drain()
+
+    async def test_one_task_finishing_does_not_unregister_its_namesake(self):
+        """The case that actually loses a task: the short-lived one completes and its
+        done handler removes the entry belonging to the one still running."""
+        done = asyncio.Event()
+        short = self.manager.create_task(self._finishes(done), name=COLLIDING_NAME)
+        still_running = self.manager.create_task(self._blocks(), name=COLLIDING_NAME)
+
+        await done.wait()
+        await asyncio.sleep(0)  # let the done callback run
+
+        self.assertTrue(short.done())
+        self.assertFalse(still_running.done())
+        self.assertIn(still_running, self.manager.current_tasks())
+        await self._drain()
+
+    async def test_a_finished_task_is_removed_from_the_registry(self):
+        """The fix must not stop the registry from pruning completed tasks."""
+        done = asyncio.Event()
+        task = self.manager.create_task(self._finishes(done), name="solo")
+
+        await done.wait()
+        await asyncio.sleep(0)
+
+        self.assertTrue(task.done())
+        self.assertNotIn(task, self.manager.current_tasks())
+        self.assertEqual(self.manager.current_tasks(), [])
+
+    async def test_cancel_task_unregisters_it(self):
+        task = self.manager.create_task(self._blocks(), name="cancel-me")
+        self.assertIn(task, self.manager.current_tasks())
+
+        await self.manager.cancel_task(task)
+
+        self.assertNotIn(task, self.manager.current_tasks())
+
+    async def test_distinct_names_are_unaffected(self):
+        a = self.manager.create_task(self._blocks(), name="a")
+        b = self.manager.create_task(self._blocks(), name="b")
+
+        self.assertEqual(sorted(t.get_name() for t in self.manager.current_tasks()), ["a", "b"])
+        self.assertEqual({a, b}, set(self.manager.current_tasks()))
+        await self._drain()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`TaskManager` keys its registry by task name, and task names are not unique.

`CrewSession` builds a handler task's name from the session, the event and the handler function:

```python
task_name = f"{self.name}::{event_name}::{handler.__name__}::handler"
```

That is fully deterministic, so the same event firing twice while the first handler is still running produces two live tasks with identical names. `_add_task` then overwrites:

```python
name = task_data.task.get_name()
self._tasks[name] = task_data
```

and `_task_done_handler` deletes by that same shared name:

```python
if name in self._tasks:
    del self._tasks[name]
```

So the second task evicts the first from the registry, and when the first finishes it deletes the entry belonging to the second, which is still running. The live task is then invisible to `current_tasks()`.

### Reproducing

```python
import asyncio
from smallestai.atoms.crew.task_manager import TaskManager, TaskManagerParams

async def main():
    tm = TaskManager()
    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))

    first_done = asyncio.Event()
    async def quick():
        await asyncio.sleep(0.05)
        first_done.set()
    async def slow():
        await asyncio.sleep(10)

    name = "sess::on_message::handle::handler"
    t1 = tm.create_task(quick(), name=name)
    t2 = tm.create_task(slow(), name=name)
    print("registry size:", len(tm.current_tasks()), "| t1 running:", not t1.done())

    await first_done.wait()
    await asyncio.sleep(0.05)
    print("registry size:", len(tm.current_tasks()), "| t2 running:", not t2.done(),
          "| t2 tracked:", t2 in tm.current_tasks())

asyncio.run(main())
```

Before:

```text
registry size: 1 | t1 running: True
registry size: 0 | t2 running: True | t2 tracked: False
```

After:

```text
registry size: 2 | t1 running: True
registry size: 1 | t2 running: True | t2 tracked: True
```

The registry reports zero tasks while one is still running.

### Scope, honestly

`CrewSession._cleanup` keeps its own `_event_tasks` set holding the task objects, so handler tasks are still cancelled on teardown and I am not claiming they leak. What is wrong is the registry itself: `current_tasks()` is documented as "the list of currently created/registered tasks" and it under-reports, down to zero while work is in flight. Anything that trusts it as the source of truth, including the `Waiting for N tasks to complete` line in cleanup, is working from a short count.

### The change

Key `_tasks` by the task object, which is unique and hashable, instead of by its name. `_add_task` and `_task_done_handler` follow. Nothing else about the manager changes: names are still set on the task and still used for logging.

One line in `session.py` read `self.task_manager._tasks.keys()` to log task names, reaching into the registry's internals. It now takes the names from `current_tasks()`, which is the public accessor and stays correct whatever the keys are.

### Tests

`tests/custom/test_crew_task_registry.py`, five cases. Two fail on `main`: both tasks sharing a name are registered, and one finishing does not unregister its namesake. The other three pin the behaviour the fix must not break, a finished task still being pruned, `cancel_task` still unregistering, and distinct names being unaffected.

`src/smallestai/atoms/crew/**` is `.fernignore`d, so a regen keeps this.
